### PR TITLE
ConnectionInfo Struct

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+const test_files = .{ "src/main.zig", "src/connection.zig", "src/parameter.zig"};
+
 pub fn build(b: *std.build.Builder) void {
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
@@ -24,15 +26,14 @@ pub fn build(b: *std.build.Builder) void {
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    var main_tests = b.addTest("src/main.zig");
-    main_tests.setBuildMode(mode);
-    main_tests.setTarget(target);
-
-    var any_list_test = b.addTest("src/any_list.zig");
-    any_list_test.setBuildMode(mode);
-    any_list_test.setTarget(target);
-
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
-    test_step.dependOn(&any_list_test.step);
+    inline for (test_files) |filename| {
+        var tests = b.addTest(filename);
+        tests.setBuildMode(mode);
+        tests.setTarget(target);
+        tests.linkLibC();
+        tests.linkSystemLibrary("odbc32");
+
+        test_step.dependOn(&tests.step); 
+    }
 }

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -39,6 +39,129 @@ pub const Column = struct {
     }
 };
 
+pub const ConnectionInfo = struct {
+    pub const Config = struct {
+        driver: []const u8,
+        dsn: []const u8,
+        username: ?[]const u8 = null,
+        password: ?[]const u8 = null,
+    };
+
+    attributes: std.StringHashMap([]const u8),
+    arena: std.heap.ArenaAllocator,
+
+    /// Initialize a blank `ConnectionInfo` struct with an initialized `attributes` hash map
+    /// and arena allocator.
+    pub fn init(allocator: *Allocator) ConnectionInfo {
+        return .{ 
+            .attributes = std.StringHashMap([]const u8).init(allocator),
+            .arena = std.heap.ArenaAllocator.init(allocator),
+        };
+    }
+
+    /// Initialize a `ConnectionInfo` using the information provided in the config data.
+    pub fn initWithConfig(allocator: *Allocator, config: Config) !ConnectionInfo {
+        var connection_info = ConnectionInfo.init(allocator);
+        try connection_info.setDriver(config.driver);
+        try connection_info.setDSN(config.dsn);
+        if (config.username) |username| try connection_info.setUsername(username);
+        if (config.password) |password| try connection_info.setPassword(password);
+
+        return connection_info;
+    }
+
+    pub fn deinit(self: *ConnectionInfo) void {
+        self.attributes.deinit();
+        self.arena.deinit();
+    }
+
+    pub fn setAttribute(self: *ConnectionInfo, attr_name: []const u8, attr_value: []const u8) !void {
+        try self.attributes.put(attr_name, attr_value);
+    }
+
+    pub fn getAttribute(self: *ConnectionInfo, attr_name: []const u8) ?[]const u8 {
+        return self.attributes.get(attr_name);
+    }
+
+    pub fn setDriver(self: *ConnectionInfo, driver_value: []const u8) !void {
+        try self.setAttribute("DRIVER", driver_value);
+    }
+
+    pub fn getDriver(self: *ConnectionInfo) ?[]const u8 {
+        return self.getAttribute("DRIVER");
+    }
+
+    pub fn setUsername(self: *ConnectionInfo, user_value: []const u8) !void {
+        try self.setAttribute("UID", user_value);
+    }
+
+    pub fn getUsername(self: *ConnectionInfo) ?[]const u8 {
+        return self.getAttribute("UID");
+    }
+
+    pub fn setPassword(self: *ConnectionInfo, password_value: []const u8) !void {
+        try self.setAttribute("PWD", password_value);
+    }
+
+    pub fn getPassword(self: *ConnectionInfo) ?[]const u8 {
+        return self.getAttribute("PWD");
+    }
+
+    pub fn setDSN(self: *ConnectionInfo, dsn_value: []const u8) !void {
+        try self.setAttribute("DSN", dsn_value);
+    }
+
+    pub fn getDSN(self: *ConnectionInfo) ?[]const u8 {
+        return self.getAttribute("DSN");
+    }
+
+    pub fn toConnectionString(self: *ConnectionInfo) ![]const u8 {
+        var string_builder = std.ArrayList(u8).init(&self.arena.allocator);
+        errdefer string_builder.deinit();
+        
+        _ = try string_builder.writer().write("ODBC;");
+
+        var attribute_iter = self.attributes.iterator();
+        while (attribute_iter.next()) |entry| {
+            _ = try string_builder.writer().write(entry.key);
+            _ = try string_builder.writer().write("=");
+            _ = try string_builder.writer().write(entry.value);
+            _ = try string_builder.writer().write(";");
+        }
+
+        return string_builder.toOwnedSlice();
+    }
+
+    pub fn fromConnectionString(allocator: *Allocator, conn_str: []const u8) !ConnectionInfo {
+        var conn_info = ConnectionInfo.init(allocator);
+
+        var attr_start: usize = 0;
+        var attr_sep_index: usize = 0;
+
+        var current_index: usize = 0;
+        while (current_index < conn_str.len) : (current_index += 1) {
+            if (conn_str[current_index] == '=') {
+                attr_sep_index = current_index;
+                continue;
+            }
+
+            if (conn_str[current_index] == ';') {
+                const attr_name = conn_str[attr_start..attr_sep_index];
+                const attr_value = conn_str[attr_sep_index + 1..current_index];
+                try conn_info.setAttribute(attr_name, attr_value);  
+
+                attr_start = current_index + 1;  
+            } else if (current_index == conn_str.len - 1) {
+                const attr_name = conn_str[attr_start..attr_sep_index];
+                const attr_value = conn_str[attr_sep_index + 1..];
+                try conn_info.setAttribute(attr_name, attr_value);
+            }
+        }
+
+        return conn_info;
+    }
+};
+
 pub const DBConnection = struct {
     environment: odbc.Environment,
     connection: odbc.Connection,
@@ -55,6 +178,10 @@ pub const DBConnection = struct {
         result.allocator = allocator;
 
         return result;
+    }
+
+    pub fn initWithInfo(allocator: *Allocator, connection_info: *ConnectionInfo) !DBConnection {
+        return try DBConnection.init(allocator, try connection_info.toConnectionString());
     }
 
     pub fn deinit(self: *DBConnection) void {
@@ -170,3 +297,27 @@ pub const DBConnection = struct {
         return try odbc.Statement.init(&self.connection, self.allocator);
     }
 };
+
+test "ConnectionInfo" {
+    const allocator = std.testing.allocator;
+
+    var connection_info = ConnectionInfo.init(allocator);
+    defer connection_info.deinit();
+
+    try connection_info.setDriver("A Driver");
+    try connection_info.setDSN("Some DSN Value");
+    try connection_info.setUsername("User");
+    try connection_info.setPassword("Password");
+    try connection_info.setAttribute("RandomAttr", "Random Value");
+
+    const connection_string = try connection_info.toConnectionString();
+
+    var derived_conn_info = try ConnectionInfo.fromConnectionString(allocator, connection_string);
+    defer derived_conn_info.deinit();
+
+    std.testing.expectEqualStrings("A Driver", derived_conn_info.getDriver().?);
+    std.testing.expectEqualStrings("Some DSN Value", derived_conn_info.getDSN().?);
+    std.testing.expectEqualStrings("User", derived_conn_info.getUsername().?);
+    std.testing.expectEqualStrings("Password", derived_conn_info.getPassword().?);
+    std.testing.expectEqualStrings("Random Value", derived_conn_info.getAttribute("RandomAttr").?);
+}

--- a/src/parameter.zig
+++ b/src/parameter.zig
@@ -35,3 +35,23 @@ pub fn default(value: anytype) SqlParameter(EraseComptime(@TypeOf(value))) {
     return result;
 }
 
+test "SqlParameter defaults" {
+    const a = default(10);
+
+    std.testing.expect(a.precision == null);
+    std.testing.expect(a.value == 10);
+    std.testing.expect(@TypeOf(a.value) == i64);
+    std.testing.expect(a.c_type == .SBigInt);
+    std.testing.expect(a.sql_type == .Integer);
+}
+
+test "SqlParameter string" {
+    const param = default("some string");
+
+    std.testing.expect(param.precision == null);
+    std.testing.expect(param.value == "some string");
+    std.testing.expect(@TypeOf(param.value) == [11:0] u8);
+    std.testing.expect(param.c_type == .Char);
+    std.testing.expect(param.sql_type == .Char);
+}
+

--- a/src/prepared_statement.zig
+++ b/src/prepared_statement.zig
@@ -84,8 +84,9 @@ pub const PreparedStatement = struct {
             try self.param_data.appendSlice(self.allocator, param);
             self.param_indicators[index - 1] = @intCast(c_longlong, param.len);
         } else {
-            try self.param_data.appendSlice(self.allocator, std.mem.toBytes(@as(EraseComptime(@TypeOf(param)), param))[0..]);
-            self.param_indicators[index - 1] = @sizeOf(EraseComptime(@TypeOf(param)));
+            const ParamType = EraseComptime(@TypeOf(param));
+            try self.param_data.appendSlice(self.allocator, std.mem.toBytes(@as(ParamType, param))[0..]);
+            self.param_indicators[index - 1] = @sizeOf(ParamType);
         }
         
         const param_ptr = &self.param_data.items[param_index];


### PR DESCRIPTION
Added a `ConnectionInfo` struct that should make it simpler to build connection strings, if the user wants to build them that way. It's still completely viable to just write your own connection strings and use those.

The basic usage is as follows:

```zig
var connection_info = try ConnectionInfo.initWithConfig(allocator, .{
    .driver = "PostgreSQL Unicode(x64)",
    .dsn = "PostgreSQL35W"
});
defer connection_info.deinit();

var connection = try DBConnection.initWithInfo(allocator, &connection_info);
defer connection.deinit();
```

Currently has "priority" support for the attributes `DRIVER`, `DSN`, `USER`, and `PWD`. User can add any arbitrary attributes using the `setAttribute` function.