### PR TITLE
Custom row mapping

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -294,7 +294,7 @@ pub const DBConnection = struct {
         var statement = try self.getStatement();
         defer statement.deinit() catch |_| {};
 
-        var result_set = try ResultSet(Column).init(&statement, self.allocator);
+        var result_set = try ResultSet(Column, .row).init(self.allocator, &statement, 10);
         defer result_set.deinit();
 
         try statement.setAttribute(.{ .RowBindType = @sizeOf(FetchResult(Column)) });

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -297,27 +297,27 @@ pub const DBConnection = struct {
         var result_set = try ResultSet(Column, .row).init(self.allocator, &statement, 10);
         defer result_set.deinit();
 
-        try statement.setAttribute(.{ .RowBindType = @sizeOf(FetchResult(Column)) });
-        try statement.setAttribute(.{ .RowArraySize = 10 });
-        try statement.setAttribute(.{ .RowStatusPointer = result_set.row_status });
-        try statement.setAttribute(.{ .RowsFetchedPointer = &result_set.rows_fetched });
+        // try statement.setAttribute(.{ .RowBindType = @sizeOf(FetchResult(Column)) });
+        // try statement.setAttribute(.{ .RowArraySize = 10 });
+        // try statement.setAttribute(.{ .RowStatusPointer = result_set.row_status });
+        // try statement.setAttribute(.{ .RowsFetchedPointer = &result_set.rows_fetched });
 
         try statement.columns(catalog_name, schema_name, table_name, null);
 
-        statement.fetch() catch |err| switch (err) {
-            error.StillExecuting => {},
-            error.NoData => {},
-            else => {
-                var error_buf: [@sizeOf(odbc.Error.SqlState) * 3]u8 = undefined;
-                var fba = std.heap.FixedBufferAllocator.init(error_buf[0..]);
-                const errors = statement.getErrors(&fba.allocator) catch |_| return err;
-                for (errors) |e| {
-                    std.debug.print("Fetch Error: {s}\n", .{@tagName(e)});
-                }
+        // statement.fetch() catch |err| switch (err) {
+        //     error.StillExecuting => {},
+        //     error.NoData => {},
+        //     else => {
+        //         var error_buf: [@sizeOf(odbc.Error.SqlState) * 3]u8 = undefined;
+        //         var fba = std.heap.FixedBufferAllocator.init(error_buf[0..]);
+        //         const errors = statement.getErrors(&fba.allocator) catch |_| return err;
+        //         for (errors) |e| {
+        //             std.debug.print("Fetch Error: {s}\n", .{@tagName(e)});
+        //         }
 
-                return err;
-            }
-        };
+        //         return err;
+        //     }
+        // };
 
         return try result_set.getAllRows();
     }

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -294,30 +294,10 @@ pub const DBConnection = struct {
         var statement = try self.getStatement();
         defer statement.deinit() catch |_| {};
 
-        var result_set = try ResultSet(Column, .row).init(self.allocator, &statement, 10);
+        var result_set = try ResultSet(Column).init(self.allocator, &statement);
         defer result_set.deinit();
 
-        // try statement.setAttribute(.{ .RowBindType = @sizeOf(FetchResult(Column)) });
-        // try statement.setAttribute(.{ .RowArraySize = 10 });
-        // try statement.setAttribute(.{ .RowStatusPointer = result_set.row_status });
-        // try statement.setAttribute(.{ .RowsFetchedPointer = &result_set.rows_fetched });
-
         try statement.columns(catalog_name, schema_name, table_name, null);
-
-        // statement.fetch() catch |err| switch (err) {
-        //     error.StillExecuting => {},
-        //     error.NoData => {},
-        //     else => {
-        //         var error_buf: [@sizeOf(odbc.Error.SqlState) * 3]u8 = undefined;
-        //         var fba = std.heap.FixedBufferAllocator.init(error_buf[0..]);
-        //         const errors = statement.getErrors(&fba.allocator) catch |_| return err;
-        //         for (errors) |e| {
-        //             std.debug.print("Fetch Error: {s}\n", .{@tagName(e)});
-        //         }
-
-        //         return err;
-        //     }
-        // };
 
         return try result_set.getAllRows();
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,6 +36,11 @@ const OdbcTestType = struct {
 
         return result;
     }
+
+    fn deinit(self: *OdbcTestType, allocator: *Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.job_info.job_name);
+    }
 };
 
 pub fn main() !void {
@@ -95,18 +100,16 @@ pub fn main() !void {
         std.debug.print("Age: {}\n\n", .{result.age});
     }
 
-    const table_columns = try connection.getColumns("zig-test", "public", "odbc_zig_test");
-    defer allocator.free(table_columns);
+    // const table_columns = try connection.getColumns("zig-test", "public", "odbc_zig_test");
+    // defer allocator.free(table_columns);
 
-    std.debug.print("Found {} columns\n", .{table_columns.len});
-    for (table_columns) |*column| {
-        std.debug.print("Column Name: {s}\n", .{column.column_name});
-        std.debug.print("Column Type: {s}\n", .{@tagName(column.sql_data_type)});
-        std.debug.print("Column Nullable? {s}\n", .{@tagName(column.nullable)});
-        std.debug.print("Decimal Digits: {}\n\n", .{column.decimal_digits});
-        column.deinit(allocator);
-    }
-
-    std.debug.print("{}\n", .{odbc.sys.SQL_CP_DRIVER_AWARE});
+    // std.debug.print("Found {} columns\n", .{table_columns.len});
+    // for (table_columns) |*column| {
+    //     std.debug.print("Column Name: {s}\n", .{column.column_name});
+    //     std.debug.print("Column Type: {s}\n", .{@tagName(column.sql_data_type)});
+    //     std.debug.print("Column Nullable? {s}\n", .{@tagName(column.nullable)});
+    //     std.debug.print("Decimal Digits: {}\n\n", .{column.decimal_digits});
+    //     column.deinit(allocator);
+    // }
 
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -100,16 +100,16 @@ pub fn main() !void {
         std.debug.print("Age: {}\n\n", .{result.age});
     }
 
-    // const table_columns = try connection.getColumns("zig-test", "public", "odbc_zig_test");
-    // defer allocator.free(table_columns);
+    const table_columns = try connection.getColumns("zig-test", "public", "odbc_zig_test");
+    defer allocator.free(table_columns);
 
-    // std.debug.print("Found {} columns\n", .{table_columns.len});
-    // for (table_columns) |*column| {
-    //     std.debug.print("Column Name: {s}\n", .{column.column_name});
-    //     std.debug.print("Column Type: {s}\n", .{@tagName(column.sql_data_type)});
-    //     std.debug.print("Column Nullable? {s}\n", .{@tagName(column.nullable)});
-    //     std.debug.print("Decimal Digits: {}\n\n", .{column.decimal_digits});
-    //     column.deinit(allocator);
-    // }
+    std.debug.print("Found {} columns\n", .{table_columns.len});
+    for (table_columns) |*column| {
+        std.debug.print("Column Name: {s}\n", .{column.column_name});
+        std.debug.print("Column Type: {s}\n", .{@tagName(column.sql_data_type)});
+        std.debug.print("Column Nullable? {s}\n", .{@tagName(column.nullable)});
+        std.debug.print("Decimal Digits: {}\n\n", .{column.decimal_digits});
+        column.deinit(allocator);
+    }
 
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,7 +28,7 @@ const OdbcTestType = struct {
         job_name: []const u8
     },
 
-    pub fn fromRow(row: *Row(OdbcTestType)) !OdbcTestType {
+    pub fn fromRow(row: *Row(OdbcTestType), allocator: *Allocator) !OdbcTestType {
         var result: OdbcTestType = undefined;
         result.name = try row.get([]const u8, "name");
         result.age = try row.get(u32, "age");

--- a/src/main.zig
+++ b/src/main.zig
@@ -23,7 +23,7 @@ const Row = @import("result_set.zig").Row;
 
 const OdbcTestType = struct {
     name: []const u8,
-    age: u32,
+    age: []const u8,
     job_info: struct {
         job_name: []const u8
     },
@@ -31,7 +31,10 @@ const OdbcTestType = struct {
     pub fn fromRow(row: *Row, allocator: *Allocator) !OdbcTestType {
         var result: OdbcTestType = undefined;
         result.name = try row.get([]const u8, "name");
-        result.age = try row.get(u32, "age");
+        
+        const age = try row.get(u32, "age");
+        result.age = try std.fmt.allocPrint(allocator, "{} years old", .{age});
+
         result.job_info.job_name = try row.get([]const u8, "occupation");
 
         return result;
@@ -39,6 +42,7 @@ const OdbcTestType = struct {
 
     fn deinit(self: *OdbcTestType, allocator: *Allocator) void {
         allocator.free(self.name);
+        allocator.free(self.age);
         allocator.free(self.job_info.job_name);
     }
 };
@@ -97,7 +101,7 @@ pub fn main() !void {
         std.debug.print("Name: {s}\n", .{result.name});
         // std.debug.print("Occupation: {s}\n", .{result.occupation});
         std.debug.print("Occupation: {s}\n", .{result.job_info.job_name});
-        std.debug.print("Age: {}\n\n", .{result.age});
+        std.debug.print("Age: {s}\n\n", .{result.age});
     }
 
     const table_columns = try connection.getColumns("zig-test", "public", "odbc_zig_test");

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,7 +28,7 @@ const OdbcTestType = struct {
         job_name: []const u8
     },
 
-    pub fn fromRow(row: *Row(OdbcTestType), allocator: *Allocator) !OdbcTestType {
+    pub fn fromRow(row: *Row, allocator: *Allocator) !OdbcTestType {
         var result: OdbcTestType = undefined;
         result.name = try row.get([]const u8, "name");
         result.age = try row.get(u32, "age");

--- a/src/prepared_statement.zig
+++ b/src/prepared_statement.zig
@@ -60,7 +60,7 @@ pub const PreparedStatement = struct {
             .column => try self.statement.numResultColumns()
         };
 
-        var result_set = try ResultSet(Result, comptime getBindType(Result)).init(self.allocator, &self.statement, size);
+        var result_set = try ResultSet(Result, bind_type).init(self.allocator, &self.statement, size);
         errdefer result_set.deinit();
 
         if (bind_type == .row) {

--- a/src/result_set.zig
+++ b/src/result_set.zig
@@ -419,7 +419,7 @@ pub fn ColumnBindingResultSet(comptime Base: type) type {
                 self.is_first = false;
             }
 
-            return try Base.fromRow(&self.row);    
+            return try Base.fromRow(&self.row, self.allocator);    
         }
     };
 }

--- a/src/result_set.zig
+++ b/src/result_set.zig
@@ -73,103 +73,11 @@ pub fn FetchResult(comptime Target: type) type {
     }
 }
 
-pub const Row = struct {
-    const Self = @This();
-
-    const Column = struct {
-        name: []const u8,
-        sql_type: odbc.Types.SqlType,
-        data: []u8,
-        indicator: c_longlong,
-    };
-
-    columns: []Column,
-
-    statement: *odbc.Statement,
-    allocator: *Allocator,
-
-    fn init(allocator: *Allocator, statement: *odbc.Statement, num_columns: usize) !Self {
-        var row: Self = undefined;
-            
-        row.statement = statement;
-        row.allocator = allocator;
-
-        row.columns = try allocator.alloc(Column, num_columns);
-
-        for (row.columns) |*column, column_index| {
-            column.sql_type = (try row.statement.getColumnAttribute(column_index + 1, .Type)).Type;
-            column.name = (try row.statement.getColumnAttribute(column_index + 1, .BaseColumnName)).BaseColumnName;
-
-            const column_size = (try row.statement.getColumnAttribute(column_index + 1, .OctetLength)).OctetLength;
-
-            column.data = try allocator.alloc(u8, @intCast(usize, column_size));
-
-            try row.statement.bindColumn(
-                @intCast(u16, column_index + 1),
-                column.sql_type.defaultCType(),
-                column.data,
-                &column.indicator
-            );
-        }
-
-        return row;
-    }
-
-    fn deinit(self: *Self) void {
-        for (self.columns) |*column| {
-            self.allocator.free(column.name);
-            self.allocator.free(column.data);
-        }
-        self.allocator.free(self.columns);
-    }
-
-    pub fn get(self: *Self, comptime ColumnType: type, column_name: []const u8) !ColumnType {
-        const column_index = for (self.columns) |column, index| {
-            if (std.mem.eql(u8, column.name, column_name)) break index;
-        } else return error.ColumnNotFound;
-
-        return try self.getWithIndex(ColumnType, column_index + 1);
-    }
-
-    pub fn getWithIndex(self: *Self, comptime ColumnType: type, column_index: usize) !ColumnType {
-        const target_column = self.columns[column_index - 1];
-
-        if (target_column.indicator == odbc.sys.SQL_NULL_DATA) {
-            return switch (@typeInfo(ColumnType)) {
-                .Optional => null,
-                else => error.InvalidNullValue,
-            };
-        }
-
-        return switch (@typeInfo(ColumnType)) {
-            .Pointer => |info| switch (info.size) {
-                .Slice => blk: {
-                    const slice_length = if (target_column.indicator == odbc.sys.SQL_NTS)
-                        std.mem.indexOf(u8, target_column.data, &.{ 0x00 }) orelse target_column.data.len
-                    else
-                        @intCast(usize, target_column.indicator);
-
-                    if (slice_length > target_column.data.len) {
-                        break :blk error.InvalidString;
-                    }
-
-                    var return_buffer = try self.allocator.alloc(u8, slice_length);
-                    std.mem.copy(u8, return_buffer, target_column.data[0..slice_length]);
-
-                    break :blk return_buffer;
-                },
-                else => sliceToValue(ColumnType, target_column.data[0..@intCast(usize, target_column.indicator)]),
-            },
-            else => sliceToValue(ColumnType, target_column.data[0..@intCast(usize, target_column.indicator)])
-        };
-    }
-};
-
-pub const BindType = enum(u1) {
-    row,
-    column
-};
-
+/// RowBindingResultSet handles fetching and binding data from query executions
+/// when the bind_type has been set to .row. In order to bind data this way,
+/// `Base` must have fields that correspond with the columns in the result set.
+/// The columns will be mapped to the fields in-order, regardless of what the fields
+/// are named.
 fn RowBindingResultSet(comptime Base: type) type {
     return struct {
         const Self = @This();
@@ -188,6 +96,8 @@ fn RowBindingResultSet(comptime Base: type) type {
         allocator: *Allocator,
         statement: *odbc.Statement,
 
+        /// Initialze the ResultSet with the given batch_size. batch_size will control how many results
+        /// are fetched every time `statement.fetch()` is called.
         pub fn init(allocator: *Allocator, statement: *odbc.Statement, batch_size: usize) !Self {
             var rows = try allocator.alloc(RowType, batch_size);
             var row_status = try allocator.alloc(RowStatus, batch_size);
@@ -213,8 +123,10 @@ fn RowBindingResultSet(comptime Base: type) type {
             self.allocator.free(self.row_status);
         }
 
+        /// Keep fetching until all results have been retrieved.
         pub fn getAllRows(self: *Self) ![]Base {
             var results = try std.ArrayList(Base).initCapacity(self.allocator, self.rows_fetched);
+            errdefer results.deinit();
 
             while (try self.next()) |item| {
                 try results.append(item);
@@ -223,6 +135,9 @@ fn RowBindingResultSet(comptime Base: type) type {
             return results.toOwnedSlice();
         }
 
+        /// Get the next available row. If all current rows have been read, this will attempt to
+        /// fetch more results with `statement.fetch()`. If `statement.fetch()` returns `error.NoData`,
+        /// this will return `null`.
         pub fn next(self: *Self) !?Base {
             if (self.is_first) {
                 try self.statement.setAttribute(.{ .RowsFetchedPointer = &self.rows_fetched });
@@ -259,7 +174,10 @@ fn RowBindingResultSet(comptime Base: type) type {
             if (self.current_row >= self.rows_fetched) {
                 // Because of the param binding in PreparedStatement.fetch, this will update self.rows_fetched
                 // @todo async - Handle error.StillExecuting here
-                self.statement.fetch() catch |_| return null;
+                self.statement.fetch() catch |err| switch (err) {
+                    error.NoData => return null,
+                    else => return err
+                };
                 self.current_row = 0;
             }
 
@@ -374,6 +292,107 @@ fn RowBindingResultSet(comptime Base: type) type {
     };
 }
 
+/// `Row` represents a single record when `bind_type` is set to `.column`.
+pub const Row = struct {
+    const Self = @This();
+
+    const Column = struct {
+        name: []const u8,
+        sql_type: odbc.Types.SqlType,
+        data: []u8,
+        indicator: c_longlong,
+    };
+
+    columns: []Column,
+
+    statement: *odbc.Statement,
+    allocator: *Allocator,
+
+
+    fn init(allocator: *Allocator, statement: *odbc.Statement, num_columns: usize) !Self {
+        var row: Self = undefined;
+            
+        row.statement = statement;
+        row.allocator = allocator;
+
+        row.columns = try allocator.alloc(Column, num_columns);
+
+        for (row.columns) |*column, column_index| {
+            column.sql_type = (try row.statement.getColumnAttribute(column_index + 1, .Type)).Type;
+            column.name = (try row.statement.getColumnAttribute(column_index + 1, .BaseColumnName)).BaseColumnName;
+
+            const column_size = (try row.statement.getColumnAttribute(column_index + 1, .OctetLength)).OctetLength;
+
+            column.data = try allocator.alloc(u8, @intCast(usize, column_size));
+
+            try row.statement.bindColumn(
+                @intCast(u16, column_index + 1),
+                column.sql_type.defaultCType(),
+                column.data,
+                &column.indicator
+            );
+        }
+
+        return row;
+    }
+
+    fn deinit(self: *Self) void {
+        for (self.columns) |*column| {
+            self.allocator.free(column.name);
+            self.allocator.free(column.data);
+        }
+        self.allocator.free(self.columns);
+    }
+
+    /// Get a value from a column using the column name. Will attempt to convert whatever bytes
+    /// are stored for the column into `ColumnType`.
+    pub fn get(self: *Self, comptime ColumnType: type, column_name: []const u8) !ColumnType {
+        const column_index = for (self.columns) |column, index| {
+            if (std.mem.eql(u8, column.name, column_name)) break index;
+        } else return error.ColumnNotFound;
+
+        return try self.getWithIndex(ColumnType, column_index + 1);
+    }
+
+    /// Get a value from a column using the column index. Column indices start from 1. Will attempt to
+    /// convert whatever bytes are stored for the column into `ColumnType`.
+    pub fn getWithIndex(self: *Self, comptime ColumnType: type, column_index: usize) !ColumnType {
+        const target_column = self.columns[column_index - 1];
+
+        if (target_column.indicator == odbc.sys.SQL_NULL_DATA) {
+            return switch (@typeInfo(ColumnType)) {
+                .Optional => null,
+                else => error.InvalidNullValue,
+            };
+        }
+
+        return switch (@typeInfo(ColumnType)) {
+            .Pointer => |info| switch (info.size) {
+                .Slice => blk: {
+                    const slice_length = if (target_column.indicator == odbc.sys.SQL_NTS)
+                        std.mem.indexOf(u8, target_column.data, &.{ 0x00 }) orelse target_column.data.len
+                    else
+                        @intCast(usize, target_column.indicator);
+
+                    if (slice_length > target_column.data.len) {
+                        break :blk error.InvalidString;
+                    }
+
+                    var return_buffer = try self.allocator.alloc(u8, slice_length);
+                    std.mem.copy(u8, return_buffer, target_column.data[0..slice_length]);
+
+                    break :blk return_buffer;
+                },
+                else => sliceToValue(ColumnType, target_column.data[0..@intCast(usize, target_column.indicator)]),
+            },
+            else => sliceToValue(ColumnType, target_column.data[0..@intCast(usize, target_column.indicator)])
+        };
+    }
+};
+
+/// ColumnBindingResultSet is used when `bind_type` is set to `.column`. This will happen when a given struct
+/// has a function called `fromRow` declared on it. This result set will use that function to convert data
+/// from generic `Row` types to `Base`.
 fn ColumnBindingResultSet(comptime Base: type) type {
     return struct {
         const Self = @This();
@@ -394,9 +413,11 @@ fn ColumnBindingResultSet(comptime Base: type) type {
         pub fn deinit(self: *Self) void {
             self.row.deinit();
         }
-
+        
+        /// Keep fetching until all of the rows have been retrieved.
         pub fn getAllRows(self: *Self) ![]Base {
             var results = try std.ArrayList(Base).initCapacity(self.allocator, 50);
+            errdefer results.deinit();
 
             while (try self.next()) |item| {
                 try results.append(item);
@@ -404,7 +425,10 @@ fn ColumnBindingResultSet(comptime Base: type) type {
 
             return results.toOwnedSlice();
         }
-
+        
+        /// Get the next available result. This calls `statement.fetch()` every time, because column-wise
+        /// binding only allows for binding 1 row at a time. When `statement.fetch()` returns `error.NoData`,
+        /// this will return `null`.
         pub fn next(self: *Self) !?Base {
             self.statement.fetch() catch |err| switch (err) {
                 error.NoData => return null,
@@ -416,6 +440,10 @@ fn ColumnBindingResultSet(comptime Base: type) type {
     };
 }
 
+pub const BindType = enum(u1) {
+    row,
+    column
+};
 
 pub fn ResultSet(comptime Base: type, comptime bind_type: BindType) type {
     return switch (bind_type) {


### PR DESCRIPTION
Adding the ability to do custom mappings from result sets to structs, instead of having to define structs that perfectly match the tables. Defining structs that match the tables (and therefore will use row-wise binding under the hood) will be faster, but if you need/want customization then this will give you the ability to do that.

Here's an example:

```zig
const Data = struct {
  fieldA: u32,
  fieldB: struct {
    inner: []const u8,
  },
  fieldC: CrazyType,
  
  // If a function with this signature is defined on the struct, then `fetch(Data)` will defer to this instead
  // of trying to directly map the data.
  pub fn fromRow(row: *Row, allocator: *Allocator) !Data {
    var data: Data = undefined;
    data.fieldA = try row.get(u32, "a");
    data.fieldB.inner = try row.get([]const u8, "b");
    
    const c = try row.get([]const u8, "c");
    data.fieldC = try CrazyType.parse(c);
    
    return data;
  }
};
```

Closes #11 