### PR TITLE
Add executeDirect()

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -257,7 +257,7 @@ pub const DBConnection = struct {
         }
     }
 
-    pub fn executeDirect(self: *DBConnection, comptime ResultType: type, statement: *odbc.Statement, sql_statement: []const u8, params: anytype) !ResultSet(ResultType) {
+    pub fn executeDirect(self: *DBConnection, comptime ResultType: type, sql_statement: []const u8, params: anytype) !ResultSet(ResultType) {
         var num_params: usize = 0;
         for (sql_statement) |c| {
             if (c == '?') num_params += 1;
@@ -265,18 +265,8 @@ pub const DBConnection = struct {
 
         if (num_params != params.len) return error.InvalidNumParams;
 
-        // var statement = self.getStatement() catch |stmt_err| {
-        //     var error_buf: [@sizeOf(odbc.Error.SqlState) * 3]u8 = undefined;
-        //     var fba = std.heap.FixedBufferAllocator.init(error_buf[0..]);
-
-        //     const errors = try self.connection.getErrors(&fba.allocator);
-
-        //     for (errors) |e| {
-        //         std.debug.print("Statement init error: {s}\n", .{@tagName(e)});
-        //     }
-        //     return error.StatementError;
-        // };
-        // errdefer statement.deinit() catch |_| {};
+        var statement = try self.getStatement();
+        errdefer statement.deinit() catch |_| {};
 
         var parameter_bucket = try ParameterBucket.init(self.allocator, num_params);
         defer parameter_bucket.deinit();
@@ -297,7 +287,6 @@ pub const DBConnection = struct {
 
         _ = try statement.executeDirect(sql_statement);
 
-        // return try ResultSet(ResultType).init(self.allocator, &statement);
         return try ResultSet(ResultType).init(self.allocator, statement);
     }
 
@@ -338,7 +327,7 @@ pub const DBConnection = struct {
         var statement = try self.getStatement();
         defer statement.deinit() catch |_| {};
 
-        var result_set = try ResultSet(Column).init(self.allocator, &statement);
+        var result_set = try ResultSet(Column).init(self.allocator, statement);
         defer result_set.deinit();
 
         try statement.columns(catalog_name, schema_name, table_name, null);

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -257,7 +257,7 @@ pub const DBConnection = struct {
         }
     }
 
-    pub fn executeDirect(self: *DBConnection, comptime ResultType: type, sql_statement: []const u8, params: anytype) !ResultSet(ResultType) {
+    pub fn executeDirect(self: *DBConnection, comptime ResultType: type, params: anytype, sql_statement: []const u8) !ResultSet(ResultType) {
         var num_params: usize = 0;
         for (sql_statement) |c| {
             if (c == '?') num_params += 1;

--- a/src/main.zig
+++ b/src/main.zig
@@ -72,32 +72,32 @@ pub fn main() !void {
     // });
 
     // var prepared_statement = try connection.prepareStatement("SELECT * FROM odbc_zig_test WHERE occupation = ?");
-    // var prepared_statement = try connection.prepareStatement(
-    //     \\SELECT *  
-    //     \\FROM odbc_zig_test 
-    //     \\WHERE name = ? OR age < ?
-    // );
-    // // var prepared_statement = try connection.prepareStatement("SELECT * FROM odbc_zig_test");
-    // defer prepared_statement.deinit();
-
-    // try prepared_statement.addParams(.{
-    //     .{1, "Reese"},
-    //     .{2, 30},
-    // });
-
-    // var result_set = try prepared_statement.fetch(OdbcTestType);
-    // defer result_set.deinit();
-    
-    var result_set = try connection.executeDirect(OdbcTestType,
-        \\SELECT *
-        \\FROM odbc_zig_test
+    var prepared_statement = try connection.prepareStatement(
+        \\SELECT *  
+        \\FROM odbc_zig_test 
         \\WHERE name = ? OR age < ?
-        ,.{ "Reese", 30 }
     );
-    defer {
-        result_set.close() catch |_| {};
-        result_set.deinit();
-    }
+    // // var prepared_statement = try connection.prepareStatement("SELECT * FROM odbc_zig_test");
+    defer prepared_statement.deinit();
+
+    try prepared_statement.addParams(.{
+        .{1, "Reese"},
+        .{2, 30},
+    });
+
+    var result_set = try prepared_statement.execute(OdbcTestType);
+    defer result_set.deinit();
+    
+    // var result_set = try connection.executeDirect(OdbcTestType,
+    //     \\SELECT *
+    //     \\FROM odbc_zig_test
+    //     \\WHERE name = ? OR age < ?
+    //     ,.{ "Reese", 30 }
+    // );
+    // defer {
+    //     result_set.close() catch |_| {};
+    //     result_set.deinit();
+    // }
 
     const query_results: []OdbcTestType = try result_set.getAllRows();
     defer {

--- a/src/main.zig
+++ b/src/main.zig
@@ -72,20 +72,29 @@ pub fn main() !void {
     // });
 
     // var prepared_statement = try connection.prepareStatement("SELECT * FROM odbc_zig_test WHERE occupation = ?");
-    var prepared_statement = try connection.prepareStatement(
-        \\SELECT *  
-        \\FROM odbc_zig_test 
-        // \\WHERE name = ? OR age < ?
-    );
-    // var prepared_statement = try connection.prepareStatement("SELECT * FROM odbc_zig_test");
-    defer prepared_statement.deinit();
+    // var prepared_statement = try connection.prepareStatement(
+    //     \\SELECT *  
+    //     \\FROM odbc_zig_test 
+    //     \\WHERE name = ? OR age < ?
+    // );
+    // // var prepared_statement = try connection.prepareStatement("SELECT * FROM odbc_zig_test");
+    // defer prepared_statement.deinit();
 
     // try prepared_statement.addParams(.{
     //     .{1, "Reese"},
     //     .{2, 30},
     // });
 
-    var result_set = try prepared_statement.fetch(OdbcTestType);
+    // var result_set = try prepared_statement.fetch(OdbcTestType);
+    // defer result_set.deinit();
+    
+    var statement = try connection.getStatement();
+    var result_set = try connection.executeDirect(OdbcTestType, &statement, 
+        \\SELECT *
+        \\FROM odbc_zig_test
+        \\WHERE name = ? OR age < ?
+        ,.{ "Reese", 30 }
+    );
     defer result_set.deinit();
 
     // std.debug.print("Rows fetched: {}\n", .{result_set.rows_fetched});

--- a/src/main.zig
+++ b/src/main.zig
@@ -72,32 +72,33 @@ pub fn main() !void {
     // });
 
     // var prepared_statement = try connection.prepareStatement("SELECT * FROM odbc_zig_test WHERE occupation = ?");
-    var prepared_statement = try connection.prepareStatement(
-        \\SELECT *  
-        \\FROM odbc_zig_test 
+    // // var prepared_statement = try connection.prepareStatement("SELECT * FROM odbc_zig_test");
+    // var prepared_statement = try connection.prepareStatement(
+    //     \\SELECT *  
+    //     \\FROM odbc_zig_test 
+    //     \\WHERE name = ? OR age < ?
+    // );
+    // defer prepared_statement.deinit();
+
+    // try prepared_statement.addParams(.{
+    //     .{1, "Reese"},
+    //     .{2, 30},
+    // });
+
+    // var result_set = try prepared_statement.execute(OdbcTestType);
+    // defer result_set.deinit();
+    
+    var result_set = try connection.executeDirect(
+        OdbcTestType,
+        .{ "Reese", 30 },
+        \\SELECT *
+        \\FROM odbc_zig_test
         \\WHERE name = ? OR age < ?
     );
-    // // var prepared_statement = try connection.prepareStatement("SELECT * FROM odbc_zig_test");
-    defer prepared_statement.deinit();
-
-    try prepared_statement.addParams(.{
-        .{1, "Reese"},
-        .{2, 30},
-    });
-
-    var result_set = try prepared_statement.execute(OdbcTestType);
-    defer result_set.deinit();
-    
-    // var result_set = try connection.executeDirect(OdbcTestType,
-    //     \\SELECT *
-    //     \\FROM odbc_zig_test
-    //     \\WHERE name = ? OR age < ?
-    //     ,.{ "Reese", 30 }
-    // );
-    // defer {
-    //     result_set.close() catch |_| {};
-    //     result_set.deinit();
-    // }
+    defer {
+        result_set.close() catch |_| {};
+        result_set.deinit();
+    }
 
     const query_results: []OdbcTestType = try result_set.getAllRows();
     defer {

--- a/src/main.zig
+++ b/src/main.zig
@@ -98,7 +98,6 @@ pub fn main() !void {
         result_set.close() catch |_| {};
         result_set.deinit();
     }
-    std.debug.print("Got result set\n", .{});
 
     const query_results: []OdbcTestType = try result_set.getAllRows();
     defer {

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,43 +9,43 @@ const ConnectionInfo = db_connection.ConnectionInfo;
 
 const Row = @import("result_set.zig").Row;
 
-// const OdbcTestType = struct {
-//     id: u32,
-//     name: []const u8,
-//     occupation: []const u8,
-//     age: u32,
-
-//     fn deinit(self: *OdbcTestType, allocator: *Allocator) void {
-//         allocator.free(self.name);
-//         allocator.free(self.occupation);
-//     }
-// };
-
 const OdbcTestType = struct {
+    id: u32,
     name: []const u8,
-    age: []const u8,
-    job_info: struct {
-        job_name: []const u8
-    },
-
-    pub fn fromRow(row: *Row, allocator: *Allocator) !OdbcTestType {
-        var result: OdbcTestType = undefined;
-        result.name = try row.get([]const u8, "name");
-        
-        const age = try row.get(u32, "age");
-        result.age = try std.fmt.allocPrint(allocator, "{} years old", .{age});
-
-        result.job_info.job_name = try row.get([]const u8, "occupation");
-
-        return result;
-    }
+    occupation: []const u8,
+    age: u32,
 
     fn deinit(self: *OdbcTestType, allocator: *Allocator) void {
         allocator.free(self.name);
-        allocator.free(self.age);
-        allocator.free(self.job_info.job_name);
+        allocator.free(self.occupation);
     }
 };
+
+// const OdbcTestType = struct {
+//     name: []const u8,
+//     age: []const u8,
+//     job_info: struct {
+//         job_name: []const u8
+//     },
+
+//     pub fn fromRow(row: *Row, allocator: *Allocator) !OdbcTestType {
+//         var result: OdbcTestType = undefined;
+//         result.name = try row.get([]const u8, "name");
+        
+//         const age = try row.get(u32, "age");
+//         result.age = try std.fmt.allocPrint(allocator, "{} years old", .{age});
+
+//         result.job_info.job_name = try row.get([]const u8, "occupation");
+
+//         return result;
+//     }
+
+//     fn deinit(self: *OdbcTestType, allocator: *Allocator) void {
+//         allocator.free(self.name);
+//         allocator.free(self.age);
+//         allocator.free(self.job_info.job_name);
+//     }
+// };
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -88,16 +88,17 @@ pub fn main() !void {
     // var result_set = try prepared_statement.fetch(OdbcTestType);
     // defer result_set.deinit();
     
-    var statement = try connection.getStatement();
-    var result_set = try connection.executeDirect(OdbcTestType, &statement, 
+    var result_set = try connection.executeDirect(OdbcTestType,
         \\SELECT *
         \\FROM odbc_zig_test
         \\WHERE name = ? OR age < ?
         ,.{ "Reese", 30 }
     );
-    defer result_set.deinit();
-
-    // std.debug.print("Rows fetched: {}\n", .{result_set.rows_fetched});
+    defer {
+        result_set.close() catch |_| {};
+        result_set.deinit();
+    }
+    std.debug.print("Got result set\n", .{});
 
     const query_results: []OdbcTestType = try result_set.getAllRows();
     defer {
@@ -105,24 +106,25 @@ pub fn main() !void {
         allocator.free(query_results);
     }
 
+
     for (query_results) |result| {
         // std.debug.print("Id: {}\n", .{result.id});
         std.debug.print("Name: {s}\n", .{result.name});
-        // std.debug.print("Occupation: {s}\n", .{result.occupation});
-        std.debug.print("Occupation: {s}\n", .{result.job_info.job_name});
-        std.debug.print("Age: {s}\n\n", .{result.age});
+        std.debug.print("Occupation: {s}\n", .{result.occupation});
+        // std.debug.print("Occupation: {s}\n", .{result.job_info.job_name});
+        std.debug.print("Age: {}\n\n", .{result.age});
     }
 
-    const table_columns = try connection.getColumns("zig-test", "public", "odbc_zig_test");
-    defer allocator.free(table_columns);
+    // const table_columns = try connection.getColumns("zig-test", "public", "odbc_zig_test");
+    // defer allocator.free(table_columns);
 
-    std.debug.print("Found {} columns\n", .{table_columns.len});
-    for (table_columns) |*column| {
-        std.debug.print("Column Name: {s}\n", .{column.column_name});
-        std.debug.print("Column Type: {s}\n", .{@tagName(column.sql_data_type)});
-        std.debug.print("Column Nullable? {s}\n", .{@tagName(column.nullable)});
-        std.debug.print("Decimal Digits: {}\n\n", .{column.decimal_digits});
-        column.deinit(allocator);
-    }
+    // std.debug.print("Found {} columns\n", .{table_columns.len});
+    // for (table_columns) |*column| {
+    //     std.debug.print("Column Name: {s}\n", .{column.column_name});
+    //     std.debug.print("Column Type: {s}\n", .{@tagName(column.sql_data_type)});
+    //     std.debug.print("Column Nullable? {s}\n", .{@tagName(column.nullable)});
+    //     std.debug.print("Decimal Digits: {}\n\n", .{column.decimal_digits});
+    //     column.deinit(allocator);
+    // }
 
 }

--- a/src/parameter.zig
+++ b/src/parameter.zig
@@ -42,7 +42,6 @@ pub const ParameterBucket = struct {
         indicator: *c_longlong,
     };
 
-    // data: std.ArrayListAlignedUnmanaged(u8, null),
     data: std.ArrayListAlignedUnmanaged(u8, null),
     param_indices: std.ArrayListUnmanaged(usize),
     indicators: []c_longlong,
@@ -52,7 +51,6 @@ pub const ParameterBucket = struct {
     pub fn init(allocator: *Allocator, num_params: usize) !ParameterBucket {
         return ParameterBucket{
             .allocator = allocator,
-            // .data = try std.ArrayListAlignedUnmanaged(u8, null).initCapacity(allocator, num_params * 8),
             .data = try std.ArrayListAlignedUnmanaged(u8, null).initCapacity(allocator, num_params * 8),
             .param_indices = try std.ArrayListUnmanaged(usize).initCapacity(allocator, num_params),
             .indicators = try allocator.alloc(c_longlong, num_params)
@@ -60,7 +58,6 @@ pub const ParameterBucket = struct {
     }
 
     pub fn deinit(self: *ParameterBucket) void {
-        // for (self.data.items) |ptr| self.allocator.destroy(ptr);
         self.data.deinit(self.allocator);
         self.param_indices.deinit(self.allocator);
         self.allocator.free(self.indicators);
@@ -80,40 +77,11 @@ pub const ParameterBucket = struct {
             self.indicators[index] = @sizeOf(ParamType);
         }
         
-        // const param_ptr = @ptrCast(*ParamType, @alignCast(@alignOf(ParamType), &self.data.items[param_index]));
-
         return Param{
             .param = @ptrCast(*c_void, &self.data.items[param_index]),
             .indicator = &self.indicators[index]
         };
     }
-
-    // pub fn addParameter(self: *ParameterBucket, index: usize, param: anytype) !Param(@TypeOf(param)) {
-    //     const ParamType = EraseComptime(@TypeOf(param));
-
-    //     const param_index = self.data.items.len;
-    //     var param_ptr = try self.allocator.create(ParamType);
-    //     param_ptr.* = param;
-
-    //     try self.data.append(self.allocator, @ptrCast(*c_void, param_ptr));
-        
-    //     self.indicators[index] = if (comptime std.meta.trait.isZigString(ParamType)) @intCast(c_longlong, param.len) else @sizeOf(ParamType);
-    //     // if (comptime std.meta.trait.isZigString(ParamType)) {
-            
-    //     //     // try self.data.appendSlice(self.allocator, param);
-    //     //     self.indicators[index] = @intCast(c_longlong, param.len);
-    //     // } else {
-    //     //     // try self.data.appendSlice(self.allocator, std.mem.toBytes(@as(ParamType, param))[0..]);
-    //     //     self.indicators[index] = @sizeOf(ParamType);
-    //     // }
-        
-    //     // const param_ptr = @ptrCast(*ParamType, @alignCast(@alignOf(ParamType), &self.data.items[param_index]));
-
-    //     return Param(@TypeOf(param)){
-    //         .param = param_ptr,
-    //         .index = param_index,
-    //     };
-    // }
 };
 
 test "SqlParameter defaults" {

--- a/src/prepared_statement.zig
+++ b/src/prepared_statement.zig
@@ -16,11 +16,6 @@ pub const PreparedStatement = struct {
     statement: odbc.Statement,
     num_params: usize,
 
-    // Should pull out the param storing logic into it's own struct,
-    // that way the same thing can be used in isolation later when I add executeDirect()
-    // and need to store parameters in a more temporary way
-    // param_data: std.ArrayListUnmanaged(u8),
-    // param_indicators: []c_longlong,
     parameters: ParameterBucket,
 
     allocator: *Allocator,
@@ -29,8 +24,6 @@ pub const PreparedStatement = struct {
         return PreparedStatement{ 
             .statement = statement, 
             .num_params = num_params, 
-            // .param_data = try std.ArrayListUnmanaged(u8).initCapacity(allocator, num_params * 8), 
-            // .param_indicators = try allocator.alloc(c_longlong, num_params), 
             .parameters = try ParameterBucket.init(allocator, num_params),
             .allocator = allocator 
         };
@@ -39,8 +32,6 @@ pub const PreparedStatement = struct {
     /// Free allocated memory, close any open cursors, and deinitialize the statement. The underlying statement
     /// will become invalidated after calling this function.
     pub fn deinit(self: *PreparedStatement) void {
-        // self.param_data.deinit(self.allocator);
-        // self.allocator.free(self.param_indicators);
         self.parameters.deinit();
         self.close() catch |_| {};
         self.statement.deinit() catch |_| {};

--- a/src/prepared_statement.zig
+++ b/src/prepared_statement.zig
@@ -46,19 +46,11 @@ pub const PreparedStatement = struct {
         self.statement.deinit() catch |_| {};
     }
 
-    pub fn execute(self: *PreparedStatement) !void {
-        _ = try self.statement.execute();
-    }
-
     /// Execute the current statement, binding the result columns to the fields of the type `Result`.
     /// Returns a ResultSet from which each row can be retrieved.
-    pub fn fetch(self: *PreparedStatement, comptime Result: type) !ResultSet(Result) {
-        const RowType = FetchResult(Result);
-
-        try self.execute();
-
+    pub fn execute(self: *PreparedStatement, comptime Result: type) !ResultSet(Result) {
+        _ = try self.statement.execute();
         return try ResultSet(Result).init(self.allocator, self.statement);
-        // return result_set;
     }
 
     /// Bind a value to a parameter index on the current statement. Parameter indices start at `1`.

--- a/src/prepared_statement.zig
+++ b/src/prepared_statement.zig
@@ -8,32 +8,40 @@ const FetchResult = @import("result_set.zig").FetchResult;
 
 const EraseComptime = @import("util.zig").EraseComptime;
 const sql_parameter = @import("parameter.zig");
+const ParameterBucket = sql_parameter.ParameterBucket;
 
 /// A prepared statement is created by submitting a SQL statement prior to execution. This allows the statement
 /// to be executed multiple times without having to re-prepare the query.
 pub const PreparedStatement = struct {
     statement: odbc.Statement,
     num_params: usize,
-    param_data: std.ArrayListUnmanaged(u8),
-    param_indicators: []c_longlong,
+
+    // Should pull out the param storing logic into it's own struct,
+    // that way the same thing can be used in isolation later when I add executeDirect()
+    // and need to store parameters in a more temporary way
+    // param_data: std.ArrayListUnmanaged(u8),
+    // param_indicators: []c_longlong,
+    parameters: ParameterBucket,
 
     allocator: *Allocator,
 
     pub fn init(allocator: *Allocator, statement: odbc.Statement, num_params: usize) !PreparedStatement {
-        return PreparedStatement{
-            .statement = statement,
-            .num_params = num_params,
-            .param_data = try std.ArrayListUnmanaged(u8).initCapacity(allocator, num_params * 8),
-            .param_indicators = try allocator.alloc(c_longlong, num_params),
-            .allocator = allocator
+        return PreparedStatement{ 
+            .statement = statement, 
+            .num_params = num_params, 
+            // .param_data = try std.ArrayListUnmanaged(u8).initCapacity(allocator, num_params * 8), 
+            // .param_indicators = try allocator.alloc(c_longlong, num_params), 
+            .parameters = try ParameterBucket.init(allocator, num_params),
+            .allocator = allocator 
         };
     }
 
     /// Free allocated memory, close any open cursors, and deinitialize the statement. The underlying statement
     /// will become invalidated after calling this function.
     pub fn deinit(self: *PreparedStatement) void {
-        self.param_data.deinit(self.allocator);
-        self.allocator.free(self.param_indicators);
+        // self.param_data.deinit(self.allocator);
+        // self.allocator.free(self.param_indicators);
+        self.parameters.deinit();
         self.close() catch |_| {};
         self.statement.deinit() catch |_| {};
     }
@@ -69,7 +77,7 @@ pub const PreparedStatement = struct {
                 }
 
                 return err;
-            }
+            },
         };
 
         return result_set;
@@ -79,26 +87,27 @@ pub const PreparedStatement = struct {
     pub fn addParam(self: *PreparedStatement, index: usize, param: anytype) !void {
         if (index > self.num_params) return error.InvalidParamIndex;
 
-        const param_index = self.param_data.items.len;
-        if (comptime std.meta.trait.isZigString(@TypeOf(param))) {
-            try self.param_data.appendSlice(self.allocator, param);
-            self.param_indicators[index - 1] = @intCast(c_longlong, param.len);
-        } else {
-            const ParamType = EraseComptime(@TypeOf(param));
-            try self.param_data.appendSlice(self.allocator, std.mem.toBytes(@as(ParamType, param))[0..]);
-            self.param_indicators[index - 1] = @sizeOf(ParamType);
-        }
-        
-        const param_ptr = &self.param_data.items[param_index];
+        // const param_index = self.param_data.items.len;
+        // if (comptime std.meta.trait.isZigString(@TypeOf(param))) {
+        //     try self.param_data.appendSlice(self.allocator, param);
+        //     self.param_indicators[index - 1] = @intCast(c_longlong, param.len);
+        // } else {
+        //     const ParamType = EraseComptime(@TypeOf(param));
+        //     try self.param_data.appendSlice(self.allocator, std.mem.toBytes(@as(ParamType, param))[0..]);
+        //     self.param_indicators[index - 1] = @sizeOf(ParamType);
+        // }
+
+        // const param_ptr = &self.param_data.items[param_index];
+        const param_ptr = self.parameters.addParameter(index - 1, param);
         const sql_param = sql_parameter.default(param);
 
         try self.statement.bindParameter(
-            @intCast(u16, index),
-            .Input,
-            sql_param.c_type,
-            sql_param.sql_type,
-            @ptrCast(*c_void, param_ptr),
-            sql_param.precision,
+            @intCast(u16, index), 
+            .Input, 
+            sql_param.c_type, 
+            sql_param.sql_type, 
+            @ptrCast(*c_void, param_ptr), 
+            sql_param.precision, 
             &self.param_indicators[index - 1]
         );
     }
@@ -121,5 +130,4 @@ pub const PreparedStatement = struct {
             return err;
         };
     }
-
 };

--- a/src/prepared_statement.zig
+++ b/src/prepared_statement.zig
@@ -57,7 +57,7 @@ pub const PreparedStatement = struct {
 
         try self.execute();
 
-        return try ResultSet(Result).init(self.allocator, &self.statement);
+        return try ResultSet(Result).init(self.allocator, self.statement);
         // return result_set;
     }
 

--- a/src/result_set.zig
+++ b/src/result_set.zig
@@ -165,7 +165,6 @@ fn RowBindingResultSet(comptime Base: type) type {
             try result.statement.setAttribute(.{ .RowBindType = @sizeOf(RowType) });
             try result.statement.setAttribute(.{ .RowArraySize = 20 });
             try result.statement.setAttribute(.{ .RowStatusPointer = result.row_status });
-            try result.statement.setAttribute(.{ .RowsFetchedPointer = &result.rows_fetched });
 
             try result.bindColumns();
 
@@ -390,16 +389,10 @@ fn ColumnBindingResultSet(comptime Base: type) type {
             result.statement = statement;
             result.allocator = allocator;
 
-
             const num_columns = try result.statement.numResultColumns();
-            
             result.row = try Row.init(allocator, &result.statement, num_columns);
+
             return result;
-            // return Self{
-            //     .statement = statement,
-            //     .allocator = allocator,
-            //     .row = try Row.init(allocator, statement, num_columns)
-            // };
         }
 
         pub fn deinit(self: *Self) void {


### PR DESCRIPTION
Adding support for **SQLExecuteDirect** via the new function `DBConnection.executeDirect()`. While execute direct itself is not a very complicated function, there were some things that had to be changed in order to support it here:

1. The main issue was parameter binding - previously parameters would be allocated on the heap and stored in a buffer on `PreparedStatement`. Since `executeDirect` doesn't generate a prepared statement, this logic had to be either duplicated or moved elsewhere. I opted to create a new struct, `ParameterBucket`, which would do the job of persisting parameters and indicators for the duration of their lifetimes. `PreparedStatement` was updated to use `ParameterBucket` as well.
2. `ResultSet` had to be changed to accept an `odbc.Statement` instead of `*odbc.Statement` in `ResultSet.init`, since the statement generated in `executeDirect` had a shorted lifetime than the `ResultSet`. While making this change I also refactored `RowBindingResultSet` so that the data conversion logic that was previously in `next()` was moved to `FetchResult`. This allowed me to greatly simplify `next()`.

Closes #14 