### PR TITLE
Updates for zig 0.9.0

### DIFF
--- a/src/catalog.zig
+++ b/src/catalog.zig
@@ -23,7 +23,7 @@ pub const Column = struct {
     ordinal_position: u32,
     is_nullable: ?[]const u8,
 
-    pub fn deinit(self: *Column, allocator: *Allocator) void {
+    pub fn deinit(self: *Column, allocator: Allocator) void {
         if (self.table_category) |tc| allocator.free(tc);
         if (self.table_schema) |ts| allocator.free(ts);
         allocator.free(self.table_name);
@@ -61,7 +61,7 @@ pub const Table = struct {
     table_type: ?[]const u8,
     remarks: ?[]const u8,
 
-    pub fn deinit(self: *Table, allocator: *Allocator) void {
+    pub fn deinit(self: *Table, allocator: Allocator) void {
         if (self.catalog) |cat| allocator.free(cat);
         if (self.schema) |schema| allocator.free(schema);
         if (self.name) |name| allocator.free(name);
@@ -98,7 +98,7 @@ pub const TablePrivileges = struct {
     privilege: []const u8,
     is_grantable: ?[]const u8,
 
-    pub fn deinit(self: *TablePrivileges, allocator: *Allocator) void {
+    pub fn deinit(self: *TablePrivileges, allocator: Allocator) void {
         if (self.category) |category| allocator.free(category);
         if (self.schema) |schema| allocator.free(schema);
         if (self.grantor) |grantor| allocator.free(grantor);

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -28,14 +28,14 @@ pub const ConnectionInfo = struct {
 
     /// Initialize a blank `ConnectionInfo` struct with an initialized `attributes` hash map
     /// and arena allocator.
-    pub fn init(allocator: *Allocator) ConnectionInfo {
+    pub fn init(allocator: Allocator) ConnectionInfo {
         return .{ 
             .attributes = std.StringHashMap([]const u8).init(allocator),
         };
     }
 
     /// Initialize a `ConnectionInfo` using the information provided in the config data.
-    pub fn initWithConfig(allocator: *Allocator, config: Config) !ConnectionInfo {
+    pub fn initWithConfig(allocator: Allocator, config: Config) !ConnectionInfo {
         var connection_info = ConnectionInfo.init(allocator);
         if (config.driver) |driver| try connection_info.setDriver(driver);
         if (config.dsn) |dsn| try connection_info.setDSN(dsn);
@@ -89,7 +89,7 @@ pub const ConnectionInfo = struct {
         return self.getAttribute("DSN");
     }
 
-    pub fn toConnectionString(self: *ConnectionInfo, allocator: *Allocator) ![]const u8 {
+    pub fn toConnectionString(self: *ConnectionInfo, allocator: Allocator) ![]const u8 {
         var string_builder = std.ArrayList(u8).init(allocator);
         errdefer string_builder.deinit();
         
@@ -108,7 +108,7 @@ pub const ConnectionInfo = struct {
         return string_builder.toOwnedSlice();
     }
 
-    pub fn fromConnectionString(allocator: *Allocator, conn_str: []const u8) !ConnectionInfo {
+    pub fn fromConnectionString(allocator: Allocator, conn_str: []const u8) !ConnectionInfo {
         var conn_info = ConnectionInfo.init(allocator);
 
         var attr_start: usize = 0;
@@ -183,7 +183,7 @@ pub const DBConnection = struct {
         try self.connection.setAttribute(.{ .Autocommit = mode == .auto });
     }
 
-    pub fn getCursor(self: *DBConnection, allocator: *Allocator) !Cursor {
+    pub fn getCursor(self: *DBConnection, allocator: Allocator) !Cursor {
         return try Cursor.init(allocator, self.connection);
     }
 

--- a/src/cursor.zig
+++ b/src/cursor.zig
@@ -21,9 +21,9 @@ pub const Cursor = struct {
 
     connection: Connection,
     statement: Statement,
-    allocator: *Allocator,
+    allocator: Allocator,
 
-    pub fn init(allocator: *Allocator, connection: Connection) !Cursor {
+    pub fn init(allocator: Allocator, connection: Connection) !Cursor {
         return Cursor{
             .allocator = allocator,
             .connection = connection,

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,7 +15,7 @@ const OdbcTestType = struct {
     occupation: []const u8,
     age: u32,
 
-    fn deinit(self: *OdbcTestType, allocator: *Allocator) void {
+    fn deinit(self: *OdbcTestType, allocator: Allocator) void {
         allocator.free(self.name);
         allocator.free(self.occupation);
     }
@@ -28,7 +28,7 @@ const OdbcTestType = struct {
 //         job_name: []const u8
 //     },
 
-//     pub fn fromRow(row: *Row, allocator: *Allocator) !OdbcTestType {
+//     pub fn fromRow(row: *Row, allocator: Allocator) !OdbcTestType {
 //         var result: OdbcTestType = undefined;
 //         result.name = try row.get([]const u8, allocator, "name");
         
@@ -40,7 +40,7 @@ const OdbcTestType = struct {
 //         return result;
 //     }
 
-//     fn deinit(self: *OdbcTestType, allocator: *Allocator) void {
+//     fn deinit(self: *OdbcTestType, allocator: Allocator) void {
 //         allocator.free(self.name);
 //         allocator.free(self.age);
 //         allocator.free(self.job_info.job_name);
@@ -51,7 +51,7 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
 
-    const allocator = &gpa.allocator;
+    const allocator = gpa.allocator();
 
     var connection_info = try ConnectionInfo.initWithConfig(allocator, .{
         .driver = "PostgreSQL Unicode(x64)",

--- a/src/parameter.zig
+++ b/src/parameter.zig
@@ -7,7 +7,7 @@ const EraseComptime = @import("util.zig").EraseComptime;
 /// This struct contains the information necessary to communicate with the ODBC driver
 /// about the type of a value. `sql_type` is often used to tell the driver how to convert
 /// the value into one that SQL will understand, whereas `c_type` is generally used so that
-/// the driver has a way to convert a `*c_void` or `[]u8` into a value.
+/// the driver has a way to convert a `*anyopaque` or `[]u8` into a value.
 pub fn SqlParameter(comptime T: type) type {
     return struct {
         sql_type: odbc.Types.SqlType,
@@ -38,7 +38,7 @@ pub fn default(value: anytype) SqlParameter(EraseComptime(@TypeOf(value))) {
 
 pub const ParameterBucket = struct {
     pub const Param = struct {
-        param: *c_void,
+        param: *anyopaque,
         indicator: *c_longlong,
     };
 
@@ -46,9 +46,9 @@ pub const ParameterBucket = struct {
     param_indices: std.ArrayListUnmanaged(usize),
     indicators: []c_longlong,
 
-    allocator: *Allocator,
+    allocator: Allocator,
 
-    pub fn init(allocator: *Allocator, num_params: usize) !ParameterBucket {
+    pub fn init(allocator: Allocator, num_params: usize) !ParameterBucket {
         return ParameterBucket{
             .allocator = allocator,
             .data = try std.ArrayListAlignedUnmanaged(u8, null).initCapacity(allocator, num_params * 8),
@@ -80,7 +80,7 @@ pub const ParameterBucket = struct {
         }
         
         return Param{
-            .param = @ptrCast(*c_void, &self.data.items[param_index]),
+            .param = @ptrCast(*anyopaque, &self.data.items[param_index]),
             .indicator = &self.indicators[index]
         };
     }


### PR DESCRIPTION
Making the following updates in order to be buildable with zig 0.9.0:

1. Allocgate (`*Allocator` params changed to `Allocator`)
2. Changing all `c_void`'s to `anyopaque`.
3. Updating the version of `zig-odbc` to also be compliant.

This is done to support `main` as it currently exists, however there will be pretty substantial changes coming soon that will make these updates redundant. If you want to peek ahead at those check out the branch `alt-api`.