### PR TITLE
Connection updates

### DIFF
--- a/examples/src/01_basic_connect.zig
+++ b/examples/src/01_basic_connect.zig
@@ -8,32 +8,26 @@ pub fn main() anyerror!void {
 
     // The first step to using zdb is creating your data source. In this example we'll use the default postgres
     // settings and connect without using a DSN.
-    var connection_info = try Connection.ConnectionInfo.initWithConfig(allocator, .{
+    var connection_info = Connection.ConnectionConfig{
         .driver = "PostgreSQL Unicode(x64)",
         .database = "postgres",
         .server = "localhost",
         .port = "5433",
         .username = "postgres",
         .password = "postgres",
-    });
-    defer connection_info.deinit();
-
-    // You can use the ConnectionInfo struct to generate a connection string with the parameters
-    // that you set.
-    const connection_string = try connection_info.toConnectionString(allocator);
-    defer allocator.free(connection_string);
+    };
 
     // Before connecting, initialize a connection struct with the default settings.    
     var conn = try Connection.init(.{});
     defer conn.deinit();
 
-    // connectExtended is used to connect to a data source using a connection string. You can also connect to a data source
-    // using a DSN name, username, and password with connection.connect()
-    try conn.connectExtended(connection_string);
+    // connectWithConfig is used to connect to a data source using a connection string, which is generated based on the ConnectionConfig. 
+    // You can also connect to a data source using a DSN name, username, and password with connection.connect()
+    try conn.connectWithConfig(allocator, connection_info);
 
     // In order to execute statements, you have to create a Cursor object.
     var cursor = try conn.getCursor(allocator);
-    defer cursor.deinit(allocator) catch {}; 
+    defer cursor.deinit(allocator) catch {};
     
     // We'll run a simple operation on this DB to start - simply querying all the database names assocaiated with this
     // connection. Since we connected to a specific DB above, this should only return "postgres"

--- a/examples/src/03_create_and_query_table.zig
+++ b/examples/src/03_create_and_query_table.zig
@@ -9,7 +9,7 @@ pub fn main() anyerror!void {
     // In this example we'll create a new DB just like create_and_connect, but we'll also perform some inserts and
     // queries on a new table.
     // Start by connecting and initializing just like before
-    var basic_connect_config = Connection.ConnectionInfo.Config{
+    var basic_connect_config = Connection.ConnectionConfig{
         .driver = "PostgreSQL Unicode(x64)",
         .database = "postgres",
         .server = "localhost",
@@ -18,17 +18,12 @@ pub fn main() anyerror!void {
         .password = "postgres",
     };
 
-    var pg_connection_info = try Connection.ConnectionInfo.initWithConfig(allocator, basic_connect_config);
-    defer pg_connection_info.deinit();
-
-    const pg_connection_string = try pg_connection_info.toConnectionString(allocator);
-    defer allocator.free(pg_connection_string);
-    
     var conn = try Connection.init(.{});
     defer conn.deinit();
 
     {
-        try conn.connectExtended(pg_connection_string);
+        // try conn.connectExtended(pg_connection_string);
+        try conn.connectWithConfig(allocator, basic_connect_config);
         defer conn.disconnect();
 
         var cursor = try conn.getCursor(allocator);
@@ -37,16 +32,13 @@ pub fn main() anyerror!void {
         _ = try cursor.executeDirect(allocator, "CREATE DATABASE create_example WITH OWNER = postgres", .{});
     }
 
-    basic_connect_config.database = "create_example";
-    var example_connection_info = try Connection.ConnectionInfo.initWithConfig(allocator, basic_connect_config);
-    defer example_connection_info.deinit();
-
-    const example_connection_string = try example_connection_info.toConnectionString(allocator);
-    defer allocator.free(example_connection_string);
+    var example_connect_config = basic_connect_config;
+    example_connect_config.database = "create_example";
 
     {
         // Connect to the DB create_example
-        try conn.connectExtended(example_connection_string);
+        // try conn.connectExtended(example_connection_string);
+        try conn.connectWithConfig(allocator, example_connect_config);
         defer conn.disconnect();
 
         var cursor = try conn.getCursor(allocator);
@@ -135,7 +127,7 @@ pub fn main() anyerror!void {
     }
 
     {
-        try conn.connectExtended(pg_connection_string);
+        try conn.connectWithConfig(allocator, basic_connect_config);
 
         var cursor = try conn.getCursor(allocator);
         defer cursor.deinit(allocator) catch {};

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -9,140 +9,150 @@ pub const CommitMode = enum(u1) { auto, manual };
 
 const Connection = @This();
 
-pub const ConnectionInfo = struct {
-    pub const Config = struct {
-        driver: ?[]const u8 = null,
-        dsn: ?[]const u8 = null,
-        database: ?[]const u8 = null,
-        server: ?[]const u8 = null,
-        port: ?[]const u8 = null,
-        username: ?[]const u8 = null,
-        password: ?[]const u8 = null,
-    };
+// pub const ConnectionInfo = struct {
+//     pub const Config = struct {
+//         driver: ?[]const u8 = null,
+//         dsn: ?[]const u8 = null,
+//         database: ?[]const u8 = null,
+//         server: ?[]const u8 = null,
+//         port: ?[]const u8 = null,
+//         username: ?[]const u8 = null,
+//         password: ?[]const u8 = null,
+//     };
 
-    attributes: std.StringHashMap([]const u8),
+//     attributes: std.StringHashMap([]const u8),
 
-    /// Initialize a blank `ConnectionInfo` struct with an initialized `attributes` hash map
-    /// and arena allocator.
-    pub fn init(allocator: Allocator) ConnectionInfo {
-        return .{
-            .attributes = std.StringHashMap([]const u8).init(allocator),
-        };
-    }
+//     /// Initialize a blank `ConnectionInfo` struct with an initialized `attributes` hash map
+//     /// and arena allocator.
+//     pub fn init(allocator: Allocator) ConnectionInfo {
+//         return .{
+//             .attributes = std.StringHashMap([]const u8).init(allocator),
+//         };
+//     }
 
-    /// Initialize a `ConnectionInfo` using the information provided in the config data.
-    pub fn initWithConfig(allocator: Allocator, config: Config) !ConnectionInfo {
-        var connection_info = ConnectionInfo.init(allocator);
-        if (config.driver) |driver| try connection_info.setDriver(driver);
-        if (config.dsn) |dsn| try connection_info.setDSN(dsn);
-        if (config.database) |database| try connection_info.setAttribute("DATABASE", database);
-        if (config.server) |server| try connection_info.setAttribute("SERVER", server);
-        if (config.port) |port| try connection_info.setAttribute("PORT", port);
-        if (config.username) |username| try connection_info.setUsername(username);
-        if (config.password) |password| try connection_info.setPassword(password);
+//     /// Initialize a `ConnectionInfo` using the information provided in the config data.
+//     pub fn initWithConfig(allocator: Allocator, config: Config) !ConnectionInfo {
+//         var connection_info = ConnectionInfo.init(allocator);
+//         if (config.driver) |driver| try connection_info.setDriver(driver);
+//         if (config.dsn) |dsn| try connection_info.setDSN(dsn);
+//         if (config.database) |database| try connection_info.setAttribute("DATABASE", database);
+//         if (config.server) |server| try connection_info.setAttribute("SERVER", server);
+//         if (config.port) |port| try connection_info.setAttribute("PORT", port);
+//         if (config.username) |username| try connection_info.setUsername(username);
+//         if (config.password) |password| try connection_info.setPassword(password);
 
-        return connection_info;
-    }
+//         return connection_info;
+//     }
 
-    pub fn deinit(self: *ConnectionInfo) void {
-        self.attributes.deinit();
-    }
+//     pub fn deinit(self: *ConnectionInfo) void {
+//         self.attributes.deinit();
+//     }
 
-    pub fn setAttribute(self: *ConnectionInfo, attr_name: []const u8, attr_value: []const u8) !void {
-        try self.attributes.put(attr_name, attr_value);
-    }
+//     pub fn setAttribute(self: *ConnectionInfo, attr_name: []const u8, attr_value: []const u8) !void {
+//         try self.attributes.put(attr_name, attr_value);
+//     }
 
-    pub fn getAttribute(self: *ConnectionInfo, attr_name: []const u8) ?[]const u8 {
-        return self.attributes.get(attr_name);
-    }
+//     pub fn getAttribute(self: *ConnectionInfo, attr_name: []const u8) ?[]const u8 {
+//         return self.attributes.get(attr_name);
+//     }
 
-    pub fn setDriver(self: *ConnectionInfo, driver_value: []const u8) !void {
-        try self.setAttribute("DRIVER", driver_value);
-    }
+//     pub fn setDriver(self: *ConnectionInfo, driver_value: []const u8) !void {
+//         try self.setAttribute("DRIVER", driver_value);
+//     }
 
-    pub fn getDriver(self: *ConnectionInfo) ?[]const u8 {
-        return self.getAttribute("DRIVER");
-    }
+//     pub fn getDriver(self: *ConnectionInfo) ?[]const u8 {
+//         return self.getAttribute("DRIVER");
+//     }
 
-    pub fn setUsername(self: *ConnectionInfo, user_value: []const u8) !void {
-        try self.setAttribute("UID", user_value);
-    }
+//     pub fn setUsername(self: *ConnectionInfo, user_value: []const u8) !void {
+//         try self.setAttribute("UID", user_value);
+//     }
 
-    pub fn getUsername(self: *ConnectionInfo) ?[]const u8 {
-        return self.getAttribute("UID");
-    }
+//     pub fn getUsername(self: *ConnectionInfo) ?[]const u8 {
+//         return self.getAttribute("UID");
+//     }
 
-    pub fn setPassword(self: *ConnectionInfo, password_value: []const u8) !void {
-        try self.setAttribute("PWD", password_value);
-    }
+//     pub fn setPassword(self: *ConnectionInfo, password_value: []const u8) !void {
+//         try self.setAttribute("PWD", password_value);
+//     }
 
-    pub fn getPassword(self: *ConnectionInfo) ?[]const u8 {
-        return self.getAttribute("PWD");
-    }
+//     pub fn getPassword(self: *ConnectionInfo) ?[]const u8 {
+//         return self.getAttribute("PWD");
+//     }
 
-    pub fn setDSN(self: *ConnectionInfo, dsn_value: []const u8) !void {
-        try self.setAttribute("DSN", dsn_value);
-    }
+//     pub fn setDSN(self: *ConnectionInfo, dsn_value: []const u8) !void {
+//         try self.setAttribute("DSN", dsn_value);
+//     }
 
-    pub fn getDSN(self: *ConnectionInfo) ?[]const u8 {
-        return self.getAttribute("DSN");
-    }
+//     pub fn getDSN(self: *ConnectionInfo) ?[]const u8 {
+//         return self.getAttribute("DSN");
+//     }
 
-    pub fn toConnectionString(self: *ConnectionInfo, allocator: Allocator) ![]const u8 {
-        var string_builder = std.ArrayList(u8).init(allocator);
-        errdefer string_builder.deinit();
+//     pub fn toConnectionString(self: *ConnectionInfo, allocator: Allocator) ![]const u8 {
+//         var string_builder = std.ArrayList(u8).init(allocator);
+//         errdefer string_builder.deinit();
 
-        _ = try string_builder.writer().write("ODBC;");
+//         _ = try string_builder.writer().write("ODBC;");
 
-        var attribute_iter = self.attributes.iterator();
-        while (attribute_iter.next()) |entry| {
-            _ = try string_builder.writer().write(entry.key_ptr.*);
-            _ = try string_builder.writer().write("=");
-            _ = try string_builder.writer().write(entry.value_ptr.*);
-            _ = try string_builder.writer().write(";");
-        }
+//         var attribute_iter = self.attributes.iterator();
+//         while (attribute_iter.next()) |entry| {
+//             _ = try string_builder.writer().write(entry.key_ptr.*);
+//             _ = try string_builder.writer().write("=");
+//             _ = try string_builder.writer().write(entry.value_ptr.*);
+//             _ = try string_builder.writer().write(";");
+//         }
 
-        return string_builder.toOwnedSlice();
-    }
+//         return string_builder.toOwnedSlice();
+//     }
 
-    pub fn fromConnectionString(allocator: Allocator, conn_str: []const u8) !ConnectionInfo {
-        var conn_info = ConnectionInfo.init(allocator);
+//     pub fn fromConnectionString(allocator: Allocator, conn_str: []const u8) !ConnectionInfo {
+//         var conn_info = ConnectionInfo.init(allocator);
 
-        var attr_start: usize = 0;
-        var attr_sep_index: usize = 0;
+//         var attr_start: usize = 0;
+//         var attr_sep_index: usize = 0;
 
-        var current_index: usize = 0;
-        while (current_index < conn_str.len) : (current_index += 1) {
-            if (conn_str[current_index] == '=') {
-                attr_sep_index = current_index;
-                continue;
-            }
+//         var current_index: usize = 0;
+//         while (current_index < conn_str.len) : (current_index += 1) {
+//             if (conn_str[current_index] == '=') {
+//                 attr_sep_index = current_index;
+//                 continue;
+//             }
 
-            if (conn_str[current_index] == ';') {
-                const attr_name = conn_str[attr_start..attr_sep_index];
-                const attr_value = conn_str[attr_sep_index + 1 .. current_index];
-                try conn_info.setAttribute(attr_name, attr_value);
+//             if (conn_str[current_index] == ';') {
+//                 const attr_name = conn_str[attr_start..attr_sep_index];
+//                 const attr_value = conn_str[attr_sep_index + 1 .. current_index];
+//                 try conn_info.setAttribute(attr_name, attr_value);
 
-                attr_start = current_index + 1;
-            } else if (current_index == conn_str.len - 1) {
-                const attr_name = conn_str[attr_start..attr_sep_index];
-                const attr_value = conn_str[attr_sep_index + 1 ..];
-                try conn_info.setAttribute(attr_name, attr_value);
-            }
-        }
+//                 attr_start = current_index + 1;
+//             } else if (current_index == conn_str.len - 1) {
+//                 const attr_name = conn_str[attr_start..attr_sep_index];
+//                 const attr_value = conn_str[attr_sep_index + 1 ..];
+//                 try conn_info.setAttribute(attr_name, attr_value);
+//             }
+//         }
 
-        return conn_info;
-    }
+//         return conn_info;
+//     }
+// };
+
+pub const ConnectionConfig = struct {
+    driver: ?[]const u8 = null,
+    dsn: ?[]const u8 = null,
+    database: ?[]const u8 = null,
+    server: ?[]const u8 = null,
+    port: ?[]const u8 = null,
+    username: ?[]const u8 = null,
+    password: ?[]const u8 = null,
 };
 
-pub const ConnectConfig = struct {
+pub const ConnectionOptions = struct {
     version: odbc.Types.EnvironmentAttributeValue.OdbcVersion = .Odbc3,
 };
 
 environment: odbc.Environment,
 connection: odbc.Connection,
 
-pub fn init(config: ConnectConfig) !Connection {
+pub fn init(config: ConnectionOptions) !Connection {
     var connection: Connection = undefined;
 
     connection.environment = try odbc.Environment.init();
@@ -157,6 +167,43 @@ pub fn init(config: ConnectConfig) !Connection {
 
 pub fn connect(conn: *Connection, server_name: []const u8, username: []const u8, password: []const u8) !void {
     try conn.connection.connect(server_name, username, password);
+}
+
+pub fn connectWithConfig(conn: *Connection, allocator: Allocator, connection_config: ConnectionConfig) !void {
+    var buffer = std.ArrayList(u8).init(allocator);
+    defer buffer.deinit();
+
+    var string_builder = buffer.writer();
+
+    if (connection_config.driver) |driver| {
+        try string_builder.print("DRIVER={s};", .{driver});
+    }
+
+    if (connection_config.dsn) |dsn| {
+        try string_builder.print("DSN={s};", .{dsn});
+    }
+
+    if (connection_config.database) |database| {
+        try string_builder.print("DATABASE={s};", .{database});
+    }
+
+    if (connection_config.server) |server| {
+        try string_builder.print("SERVER={s};", .{server});
+    }
+
+    if (connection_config.port) |port| {
+        try string_builder.print("PORT={s};", .{port});
+    }
+
+    if (connection_config.username) |username| {
+        try string_builder.print("UID={s};", .{username});
+    }
+
+    if (connection_config.password) |password| {
+        try string_builder.print("PWD={s};", .{password});
+    }
+
+    try conn.connection.connectExtended(buffer.items, .NoPrompt);
 }
 
 pub fn connectExtended(conn: *Connection, connection_string: []const u8) !void {
@@ -180,27 +227,27 @@ pub fn getCursor(self: *Connection, allocator: Allocator) !Cursor {
     return try Cursor.init(allocator, self.connection);
 }
 
-test "ConnectionInfo" {
-    const allocator = std.testing.allocator;
+// test "ConnectionInfo" {
+//     const allocator = std.testing.allocator;
 
-    var connection_info = ConnectionInfo.init(allocator);
-    defer connection_info.deinit();
+//     var connection_info = ConnectionInfo.init(allocator);
+//     defer connection_info.deinit();
 
-    try connection_info.setDriver("A Driver");
-    try connection_info.setDSN("Some DSN Value");
-    try connection_info.setUsername("User");
-    try connection_info.setPassword("Password");
-    try connection_info.setAttribute("RandomAttr", "Random Value");
+//     try connection_info.setDriver("A Driver");
+//     try connection_info.setDSN("Some DSN Value");
+//     try connection_info.setUsername("User");
+//     try connection_info.setPassword("Password");
+//     try connection_info.setAttribute("RandomAttr", "Random Value");
 
-    const connection_string = try connection_info.toConnectionString(allocator);
-    defer allocator.free(connection_string);
+//     const connection_string = try connection_info.toConnectionString(allocator);
+//     defer allocator.free(connection_string);
 
-    var derived_conn_info = try ConnectionInfo.fromConnectionString(allocator, connection_string);
-    defer derived_conn_info.deinit();
+//     var derived_conn_info = try ConnectionInfo.fromConnectionString(allocator, connection_string);
+//     defer derived_conn_info.deinit();
 
-    try std.testing.expectEqualStrings("A Driver", derived_conn_info.getDriver().?);
-    try std.testing.expectEqualStrings("Some DSN Value", derived_conn_info.getDSN().?);
-    try std.testing.expectEqualStrings("User", derived_conn_info.getUsername().?);
-    try std.testing.expectEqualStrings("Password", derived_conn_info.getPassword().?);
-    try std.testing.expectEqualStrings("Random Value", derived_conn_info.getAttribute("RandomAttr").?);
-}
+//     try std.testing.expectEqualStrings("A Driver", derived_conn_info.getDriver().?);
+//     try std.testing.expectEqualStrings("Some DSN Value", derived_conn_info.getDSN().?);
+//     try std.testing.expectEqualStrings("User", derived_conn_info.getUsername().?);
+//     try std.testing.expectEqualStrings("Password", derived_conn_info.getPassword().?);
+//     try std.testing.expectEqualStrings("Random Value", derived_conn_info.getAttribute("RandomAttr").?);
+// }

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -9,132 +9,6 @@ pub const CommitMode = enum(u1) { auto, manual };
 
 const Connection = @This();
 
-// pub const ConnectionInfo = struct {
-//     pub const Config = struct {
-//         driver: ?[]const u8 = null,
-//         dsn: ?[]const u8 = null,
-//         database: ?[]const u8 = null,
-//         server: ?[]const u8 = null,
-//         port: ?[]const u8 = null,
-//         username: ?[]const u8 = null,
-//         password: ?[]const u8 = null,
-//     };
-
-//     attributes: std.StringHashMap([]const u8),
-
-//     /// Initialize a blank `ConnectionInfo` struct with an initialized `attributes` hash map
-//     /// and arena allocator.
-//     pub fn init(allocator: Allocator) ConnectionInfo {
-//         return .{
-//             .attributes = std.StringHashMap([]const u8).init(allocator),
-//         };
-//     }
-
-//     /// Initialize a `ConnectionInfo` using the information provided in the config data.
-//     pub fn initWithConfig(allocator: Allocator, config: Config) !ConnectionInfo {
-//         var connection_info = ConnectionInfo.init(allocator);
-//         if (config.driver) |driver| try connection_info.setDriver(driver);
-//         if (config.dsn) |dsn| try connection_info.setDSN(dsn);
-//         if (config.database) |database| try connection_info.setAttribute("DATABASE", database);
-//         if (config.server) |server| try connection_info.setAttribute("SERVER", server);
-//         if (config.port) |port| try connection_info.setAttribute("PORT", port);
-//         if (config.username) |username| try connection_info.setUsername(username);
-//         if (config.password) |password| try connection_info.setPassword(password);
-
-//         return connection_info;
-//     }
-
-//     pub fn deinit(self: *ConnectionInfo) void {
-//         self.attributes.deinit();
-//     }
-
-//     pub fn setAttribute(self: *ConnectionInfo, attr_name: []const u8, attr_value: []const u8) !void {
-//         try self.attributes.put(attr_name, attr_value);
-//     }
-
-//     pub fn getAttribute(self: *ConnectionInfo, attr_name: []const u8) ?[]const u8 {
-//         return self.attributes.get(attr_name);
-//     }
-
-//     pub fn setDriver(self: *ConnectionInfo, driver_value: []const u8) !void {
-//         try self.setAttribute("DRIVER", driver_value);
-//     }
-
-//     pub fn getDriver(self: *ConnectionInfo) ?[]const u8 {
-//         return self.getAttribute("DRIVER");
-//     }
-
-//     pub fn setUsername(self: *ConnectionInfo, user_value: []const u8) !void {
-//         try self.setAttribute("UID", user_value);
-//     }
-
-//     pub fn getUsername(self: *ConnectionInfo) ?[]const u8 {
-//         return self.getAttribute("UID");
-//     }
-
-//     pub fn setPassword(self: *ConnectionInfo, password_value: []const u8) !void {
-//         try self.setAttribute("PWD", password_value);
-//     }
-
-//     pub fn getPassword(self: *ConnectionInfo) ?[]const u8 {
-//         return self.getAttribute("PWD");
-//     }
-
-//     pub fn setDSN(self: *ConnectionInfo, dsn_value: []const u8) !void {
-//         try self.setAttribute("DSN", dsn_value);
-//     }
-
-//     pub fn getDSN(self: *ConnectionInfo) ?[]const u8 {
-//         return self.getAttribute("DSN");
-//     }
-
-//     pub fn toConnectionString(self: *ConnectionInfo, allocator: Allocator) ![]const u8 {
-//         var string_builder = std.ArrayList(u8).init(allocator);
-//         errdefer string_builder.deinit();
-
-//         _ = try string_builder.writer().write("ODBC;");
-
-//         var attribute_iter = self.attributes.iterator();
-//         while (attribute_iter.next()) |entry| {
-//             _ = try string_builder.writer().write(entry.key_ptr.*);
-//             _ = try string_builder.writer().write("=");
-//             _ = try string_builder.writer().write(entry.value_ptr.*);
-//             _ = try string_builder.writer().write(";");
-//         }
-
-//         return string_builder.toOwnedSlice();
-//     }
-
-//     pub fn fromConnectionString(allocator: Allocator, conn_str: []const u8) !ConnectionInfo {
-//         var conn_info = ConnectionInfo.init(allocator);
-
-//         var attr_start: usize = 0;
-//         var attr_sep_index: usize = 0;
-
-//         var current_index: usize = 0;
-//         while (current_index < conn_str.len) : (current_index += 1) {
-//             if (conn_str[current_index] == '=') {
-//                 attr_sep_index = current_index;
-//                 continue;
-//             }
-
-//             if (conn_str[current_index] == ';') {
-//                 const attr_name = conn_str[attr_start..attr_sep_index];
-//                 const attr_value = conn_str[attr_sep_index + 1 .. current_index];
-//                 try conn_info.setAttribute(attr_name, attr_value);
-
-//                 attr_start = current_index + 1;
-//             } else if (current_index == conn_str.len - 1) {
-//                 const attr_name = conn_str[attr_start..attr_sep_index];
-//                 const attr_value = conn_str[attr_sep_index + 1 ..];
-//                 try conn_info.setAttribute(attr_name, attr_value);
-//             }
-//         }
-
-//         return conn_info;
-//     }
-// };
-
 pub const ConnectionConfig = struct {
     driver: ?[]const u8 = null,
     dsn: ?[]const u8 = null,
@@ -143,6 +17,23 @@ pub const ConnectionConfig = struct {
     port: ?[]const u8 = null,
     username: ?[]const u8 = null,
     password: ?[]const u8 = null,
+
+    pub fn getConnectionString(config: ConnectionConfig, allocator: Allocator) ![]const u8 {
+        var buffer = std.ArrayList(u8).init(allocator);
+        errdefer buffer.deinit();
+
+        var string_builder = buffer.writer();
+
+        if (config.driver)      |driver| try string_builder.print("DRIVER={s};", .{driver});
+        if (config.dsn)         |dsn| try string_builder.print("DSN={s};", .{dsn});
+        if (config.database)    |database| try string_builder.print("DATABASE={s};", .{database});
+        if (config.server)      |server| try string_builder.print("SERVER={s};", .{server});
+        if (config.port)        |port| try string_builder.print("PORT={s};", .{port});
+        if (config.username)    |username| try string_builder.print("UID={s};", .{username});
+        if (config.password)    |password| try string_builder.print("PWD={s};", .{password});
+
+        return buffer.toOwnedSlice();
+    }
 };
 
 pub const ConnectionOptions = struct {
@@ -170,40 +61,10 @@ pub fn connect(conn: *Connection, server_name: []const u8, username: []const u8,
 }
 
 pub fn connectWithConfig(conn: *Connection, allocator: Allocator, connection_config: ConnectionConfig) !void {
-    var buffer = std.ArrayList(u8).init(allocator);
-    defer buffer.deinit();
+    var connection_string = try connection_config.getConnectionString(allocator);
+    defer allocator.free(connection_string);
 
-    var string_builder = buffer.writer();
-
-    if (connection_config.driver) |driver| {
-        try string_builder.print("DRIVER={s};", .{driver});
-    }
-
-    if (connection_config.dsn) |dsn| {
-        try string_builder.print("DSN={s};", .{dsn});
-    }
-
-    if (connection_config.database) |database| {
-        try string_builder.print("DATABASE={s};", .{database});
-    }
-
-    if (connection_config.server) |server| {
-        try string_builder.print("SERVER={s};", .{server});
-    }
-
-    if (connection_config.port) |port| {
-        try string_builder.print("PORT={s};", .{port});
-    }
-
-    if (connection_config.username) |username| {
-        try string_builder.print("UID={s};", .{username});
-    }
-
-    if (connection_config.password) |password| {
-        try string_builder.print("PWD={s};", .{password});
-    }
-
-    try conn.connection.connectExtended(buffer.items, .NoPrompt);
+    try conn.connection.connectExtended(connection_string, .NoPrompt);
 }
 
 pub fn connectExtended(conn: *Connection, connection_string: []const u8) !void {
@@ -227,27 +88,18 @@ pub fn getCursor(self: *Connection, allocator: Allocator) !Cursor {
     return try Cursor.init(allocator, self.connection);
 }
 
-// test "ConnectionInfo" {
-//     const allocator = std.testing.allocator;
+test "ConnectionInfo" {
+    const allocator = std.testing.allocator;
 
-//     var connection_info = ConnectionInfo.init(allocator);
-//     defer connection_info.deinit();
+    var connection_info = ConnectionConfig{
+        .driver = "A Driver",
+        .dsn = "Some DSN Value",
+        .username = "User",
+        .password = "Password",
+    };
 
-//     try connection_info.setDriver("A Driver");
-//     try connection_info.setDSN("Some DSN Value");
-//     try connection_info.setUsername("User");
-//     try connection_info.setPassword("Password");
-//     try connection_info.setAttribute("RandomAttr", "Random Value");
+    const connection_string = try connection_info.getConnectionString(allocator);
+    defer allocator.free(connection_string);
 
-//     const connection_string = try connection_info.toConnectionString(allocator);
-//     defer allocator.free(connection_string);
-
-//     var derived_conn_info = try ConnectionInfo.fromConnectionString(allocator, connection_string);
-//     defer derived_conn_info.deinit();
-
-//     try std.testing.expectEqualStrings("A Driver", derived_conn_info.getDriver().?);
-//     try std.testing.expectEqualStrings("Some DSN Value", derived_conn_info.getDSN().?);
-//     try std.testing.expectEqualStrings("User", derived_conn_info.getUsername().?);
-//     try std.testing.expectEqualStrings("Password", derived_conn_info.getPassword().?);
-//     try std.testing.expectEqualStrings("Random Value", derived_conn_info.getAttribute("RandomAttr").?);
-// }
+    try std.testing.expectEqualStrings("DRIVER=A Driver;DSN=Some DSN Value;UID=User;PWD=Password", connection_string);    
+}

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -24,13 +24,13 @@ pub const ConnectionConfig = struct {
 
         var string_builder = buffer.writer();
 
-        if (config.driver)      |driver| try string_builder.print("DRIVER={s};", .{driver});
-        if (config.dsn)         |dsn| try string_builder.print("DSN={s};", .{dsn});
-        if (config.database)    |database| try string_builder.print("DATABASE={s};", .{database});
-        if (config.server)      |server| try string_builder.print("SERVER={s};", .{server});
-        if (config.port)        |port| try string_builder.print("PORT={s};", .{port});
-        if (config.username)    |username| try string_builder.print("UID={s};", .{username});
-        if (config.password)    |password| try string_builder.print("PWD={s};", .{password});
+        if (config.driver)   |driver|   try string_builder.print("DRIVER={s};", .{driver});
+        if (config.dsn)      |dsn|      try string_builder.print("DSN={s};", .{dsn});
+        if (config.database) |database| try string_builder.print("DATABASE={s};", .{database});
+        if (config.server)   |server|   try string_builder.print("SERVER={s};", .{server});
+        if (config.port)     |port|     try string_builder.print("PORT={s};", .{port});
+        if (config.username) |username| try string_builder.print("UID={s};", .{username});
+        if (config.password) |password| try string_builder.print("PWD={s};", .{password});
 
         return buffer.toOwnedSlice();
     }


### PR DESCRIPTION
Updating the `Connection` API to have more sensible and user-friendly options for connecting to a database.

#### Old Version

```zig
var connection_info = try ConnectionInfo.initWithConfig(allocator, .{ .driver = "driver" });
defer connection_info.deinit();

var connection_string = try connection_info.toConnectionInfo();
defer allocator.free(connection_string);

try connection.connectExtended(allocator, connection_string);
```

#### New Version

```zig
try connection.connectWithConfig(allocator, .{ .driver = "driver" });
```

I also updated the current examples to use this new pattern.