### PR TITLE
wip: start fixing build errors for zig 0.12.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,11 +1,23 @@
 .{
     .name = "zdb",
-    .version = "0.2.0",
+    .version = "0.3.0",
+
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    .minimum_zig_version = "0.12.0",
 
     .dependencies = .{
         .zig_odbc = .{
-            .url = "https://github.com/mjoerussell/zig-odbc/archive/main.tar.gz",
-            .hash = "12201a961f7b538543444f6ca418b0ea5482c18119b4e39cf6a8abfd90471e0497b3",
+            .url = "https://github.com/rupurt/zig-odbc/archive/zig-0.12.0-support.tar.gz",
+            .hash = "122098955e514a8ac3b087ef43df206ed7a0d3c9481f6d5f918f8c8543f76b834aa4",
         },
+    },
+
+    .paths = .{
+      "build.zig",
+      "build.zig.zon",
+      "src",
+      "LICENSE",
+      "README.md",
     },
 }

--- a/examples/01_basic_connect.zig
+++ b/examples/01_basic_connect.zig
@@ -8,7 +8,7 @@ pub fn main() anyerror!void {
 
     // The first step to using zdb is creating your data source. In this example we'll use the default postgres
     // settings and connect without using a DSN.
-    var connection_info = Connection.ConnectionConfig{
+    const connection_info = Connection.ConnectionConfig{
         .driver = "PostgreSQL Unicode(x64)",
         .database = "postgres",
         .server = "localhost",
@@ -31,7 +31,7 @@ pub fn main() anyerror!void {
 
     // We'll run a simple operation on this DB to start - simply querying all the database names assocaiated with this
     // connection. Since we connected to a specific DB above, this should only return "postgres"
-    var catalogs = try cursor.catalogs(allocator);
+    const catalogs = try cursor.catalogs(allocator);
     defer allocator.free(catalogs);
 
     std.debug.print("Got {} catalogs\n", .{catalogs.len});

--- a/examples/02_connect_and_create_db.zig
+++ b/examples/02_connect_and_create_db.zig
@@ -8,7 +8,7 @@ pub fn main() anyerror!void {
 
     // In this example we'll create a new database and reconnect to it.
     // The beginning is the same as basic_connect
-    var basic_connect_config = Connection.ConnectionConfig{
+    const basic_connect_config = Connection.ConnectionConfig{
         .driver = "PostgreSQL Unicode(x64)",
         .database = "postgres",
         .server = "localhost",

--- a/examples/04_row_binding.zig
+++ b/examples/04_row_binding.zig
@@ -9,7 +9,7 @@ pub fn main() anyerror!void {
 
     // This example is the same as create_and_query_table, except we're going to see how to use RowIterator to fetch results instead of
     // ItemIterator.
-    var basic_connect_config = Connection.ConnectionConfig{
+    const basic_connect_config = Connection.ConnectionConfig{
         .driver = "PostgreSQL Unicode(x64)",
         .database = "postgres",
         .server = "localhost",
@@ -111,7 +111,7 @@ pub fn main() anyerror!void {
             // custom format strings based on the SQLType of the column, which can be checked on the Row struct. There are default
             // format strings defined for all SQLTypes already, so in most cases you don't have to specify anything and the data should
             // print in a predictable way
-            var stdout_writer = std.io.getStdOut().writer();
+            const stdout_writer = std.io.getStdOut().writer();
             try row.printColumn("age", .{}, stdout_writer);
 
             std.debug.print("\n", .{});

--- a/src/Connection.zig
+++ b/src/Connection.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-const odbc = @import("odbc");
+const odbc = @import("zig-odbc");
 
 const Cursor = @import("Cursor.zig");
 
@@ -68,7 +68,7 @@ pub fn connect(conn: *Connection, server_name: []const u8, username: []const u8,
 /// Connect to a database using a ConnectionConfig. The config will be converted to a connection string, and then
 /// it will attempt to connect using connectExtended.
 pub fn connectWithConfig(conn: *Connection, allocator: Allocator, connection_config: ConnectionConfig) !void {
-    var connection_string = try connection_config.getConnectionString(allocator);
+    const connection_string = try connection_config.getConnectionString(allocator);
     defer allocator.free(connection_string);
 
     try conn.connection.connectExtended(connection_string, .NoPrompt);
@@ -116,5 +116,5 @@ test "ConnectionInfo" {
     const connection_string = try connection_info.getConnectionString(allocator);
     defer allocator.free(connection_string);
 
-    try std.testing.expectEqualStrings("DRIVER=A Driver;DSN=Some DSN Value;UID=User;PWD=Password", connection_string);
+    try std.testing.expectEqualStrings("DRIVER={A Driver};DSN=Some DSN Value;UID=User;PWD=Password;", connection_string);
 }

--- a/src/Cursor.zig
+++ b/src/Cursor.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-const odbc = @import("odbc");
+const odbc = @import("zig-odbc");
 const Statement = odbc.Statement;
 const Connection = odbc.Connection;
 
@@ -205,8 +205,8 @@ pub fn columns(cursor: *Cursor, allocator: Allocator, catalog_name: ?[]const u8,
     errdefer column_result.deinit();
 
     while (true) {
-        var result = column_iter.next() catch continue;
-        var column = result orelse break;
+        const result = column_iter.next() catch continue;
+        const column = result orelse break;
         try column_result.append(column);
     }
 
@@ -224,8 +224,8 @@ pub fn tables(cursor: *Cursor, allocator: Allocator, catalog_name: ?[]const u8, 
     errdefer table_result.deinit();
 
     while (true) {
-        var result = table_iter.next() catch continue;
-        var table = result orelse break;
+        const result = table_iter.next() catch continue;
+        const table = result orelse break;
         try table_result.append(table);
     }
 
@@ -243,8 +243,8 @@ pub fn tablePrivileges(cursor: *Cursor, allocator: Allocator, catalog_name: ?[]c
     errdefer priv_result.deinit();
 
     while (true) {
-        var result = priv_iter.next() catch continue;
-        var privilege = result orelse break;
+        const result = priv_iter.next() catch continue;
+        const privilege = result orelse break;
         try priv_result.append(privilege);
     }
 
@@ -261,7 +261,7 @@ pub fn catalogs(cursor: *Cursor, allocator: Allocator) ![][]const u8 {
     defer iter.deinit(allocator);
 
     while (true) {
-        var result = iter.next() catch continue;
+        const result = iter.next() catch continue;
         var row = result orelse break;
         const catalog_name = row.get([]const u8, "TABLE_CAT") catch continue;
 

--- a/src/ResultSet.zig
+++ b/src/ResultSet.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-const odbc = @import("odbc");
+const odbc = @import("zig-odbc");
 const RowStatus = odbc.Types.StatementAttributeValue.RowStatus;
 const Statement = odbc.Statement;
 const CType = odbc.Types.CType;
@@ -107,7 +107,7 @@ fn toTarget(comptime Target: type, allocator: Allocator, row: FetchResult(Target
                         else
                             @as(usize, @intCast(len_or_indicator));
 
-                        var data_slice = try allocator.alloc(info.child, slice_length);
+                        const data_slice = try allocator.alloc(info.child, slice_length);
                         std.mem.copy(info.child, data_slice, row_data[0..slice_length]);
                         break :blk data_slice;
                     },
@@ -467,13 +467,13 @@ const RowIterator = struct {
     pub fn init(allocator: Allocator, statement: odbc.Statement, row_count: usize) !RowIterator {
         const num_columns = try statement.numResultColumns();
 
-        var columns = try allocator.alloc(Column, num_columns);
+        const columns = try allocator.alloc(Column, num_columns);
         errdefer {
             for (columns) |*c| c.deinit(allocator);
             allocator.free(columns);
         }
 
-        var row_status = try allocator.alloc(RowStatus, row_count);
+        const row_status = try allocator.alloc(RowStatus, row_count);
         errdefer allocator.free(row_status);
 
         try statement.setAttribute(.{ .RowBindType = odbc.sys.SQL_BIND_BY_COLUMN });

--- a/src/catalog.zig
+++ b/src/catalog.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-const odbc = @import("odbc");
+const odbc = @import("zig-odbc");
 
 /// Used for fetching column metadata from a database. Supports formatted printing by default.
 pub const Column = struct {

--- a/src/zdb.zig
+++ b/src/zdb.zig
@@ -4,4 +4,4 @@ pub const ResultSet = @import("ResultSet.zig");
 pub const Cursor = @import("Cursor.zig");
 pub const util = @import("util.zig");
 
-pub const odbc = @import("odbc");
+pub const odbc = @import("zig-odbc");


### PR DESCRIPTION
I've started updating `zdb` to try and get it running on zig 0.12 & the latest changes on `main` for `zig-odbc`

`std.meta.trait` was [removed](https://github.com/ziglang/zig/commit/d5e21a4f1a2920ef7bbe3c54feab1a3b5119bf77) and I need to resolve the module import errors

```shell
zig build test
test
└─ zig test Debug native 3 errors
src/ParameterBucket.zig:3:22: error: no module named 'zig-odbc' available within module root
const odbc = @import("zig-odbc");
                     ^~~~~~~~~~
referenced by:
    test.SqlParameter defaults: src/ParameterBucket.zig:128:21
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
src/ParameterBucket.zig:84:59: error: root struct of file 'meta' has no member named 'trait'
    const data_buffer: []const u8 = if (comptime std.meta.trait.isZigString(ParamType))
                                                          ^~~~~
/nix/store/hc4lsx51ha985cbvks9r0n5gc25ph2mh-zig-0.12.0-dev.2644+42fcca49c/lib/std/meta.zig:1:1: note: struct declared here
const std = @import("std.zig");
^~~~~
src/ParameterBucket.zig:84:59: error: root struct of file 'meta' has no member named 'trait'
    const data_buffer: []const u8 = if (comptime std.meta.trait.isZigString(ParamType))
                                                          ^~~~~
/nix/store/hc4lsx51ha985cbvks9r0n5gc25ph2mh-zig-0.12.0-dev.2644+42fcca49c/lib/std/meta.zig:1:1: note: struct declared here
const std = @import("std.zig");
^~~~~
error: the following command failed with 3 compilation errors:
/nix/store/hc4lsx51ha985cbvks9r0n5gc25ph2mh-zig-0.12.0-dev.2644+42fcca49c/bin/zig test /Users/alex/workspace/mjoerussell/zdb/zig-cache/o/f87c9835fef3336edb0dff8d4225a950/libzigodbc.0.0.0.dylib -rpath /Users/alex/workspace/mjoerussell/zdb/zig-cache/o/f87c9835fef3336edb0dff8d4225a950 -ODebug -Mroot=/Users/alex/workspace/mjoerussell/zdb/src/ParameterBucket.zig -lc -fno-emit-bin --cache-dir /Users/alex/workspace/mjoerussell/zdb/zig-cache --global-cache-dir /Users/alex/.cache/zig --name test --listen=-
Build Summary: 2/4 steps succeeded; 1 failed (disable with --summary none)
test transitive failure
└─ zig test Debug native 3 errors
error: the following build command failed with exit code 1:
/Users/alex/workspace/mjoerussell/zdb/zig-cache/o/44b0248429705ec468b74825637a9173/build /nix/store/hc4lsx51ha985cbvks9r0n5gc25ph2mh-zig-0.12.0-dev.2644+42fcca49c/bin/zig /Users/alex/workspace/mjoerussell/zdb /Users/alex/workspace/mjoerussell/zdb/zig-cache /Users/alex/.cache/zig --seed 0x926bb5f -Z9fcae9a11024e75c test
``` 